### PR TITLE
AND-1883 Fix the editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 [*.{kt,kts}]
-ktlint_code_style = official
 ktlint_ignore_back_ticked_identifier = true
 
 indent_size = 4


### PR DESCRIPTION
Пока тестировал action на форке, выяснилось, что удаленная строка вызывает краш в ktlint