### PR TITLE
AND-2596 Fix twinned cards saving

### DIFF
--- a/app/src/main/java/com/tangem/tap/domain/model/UserWallet.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/UserWallet.kt
@@ -1,5 +1,6 @@
 package com.tangem.tap.domain.model
 
+import com.tangem.common.extensions.toHexString
 import com.tangem.domain.common.ScanResponse
 import com.tangem.domain.common.util.UserWalletId
 
@@ -33,4 +34,20 @@ data class UserWallet(
         get() = scanResponse.card.wallets.isEmpty()
 
     internal var isSaved: Boolean = true
+}
+
+/**
+ * !!! Workaround !!!
+ *
+ * Calculate same [UserWalletId] for twins instead
+ * */
+fun UserWallet.isTwinnedWith(other: UserWallet): Boolean {
+    if (!scanResponse.isTangemTwins()) return false
+    if (other.scanResponse.secondTwinPublicKey == scanResponse.card.wallets.firstOrNull()?.publicKey?.toHexString()) {
+        return true
+    }
+    if (scanResponse.secondTwinPublicKey == other.scanResponse.card.wallets.firstOrNull()?.publicKey?.toHexString()) {
+        return true
+    }
+    return false
 }


### PR DESCRIPTION
Исправил, но коряво, по хорошему нужно считать user wallet ID для твинов так, что-бы у пары он был одинаковым. Сейчас с этим есть проблемы, так как `CardDTO`, на основе которого считается ID, ничего не знает о ствиненной карте. Можно было бы считать ID по `ScanResponse`, но, во первых, это не совсем корректно со стороны архитектуры, а во вторых в iOS ID считается при помощи суммирования ключей на кривой Secp256k1, но у нас нет нужных методов для этого и быстро написать их у меня не вышло