### PR TITLE
AND-2626 Update logic for saving user wallets

### DIFF
--- a/app/src/main/java/com/tangem/tap/domain/model/UserWallet.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/UserWallet.kt
@@ -15,7 +15,6 @@ import com.tangem.domain.common.util.UserWalletId
  * @property cardId ID of user's wallet primary card
  * @property hasAccessCode Indicates if the user's wallet primary card has access code
  * @property isLocked Indicates if this primary card has no currency wallets
- * @property isSaved Indicates if this user wallet is saved
  * */
 data class UserWallet(
     val name: String,
@@ -32,8 +31,6 @@ data class UserWallet(
 
     val isLocked: Boolean
         get() = scanResponse.card.wallets.isEmpty()
-
-    internal var isSaved: Boolean = true
 }
 
 /**

--- a/app/src/main/java/com/tangem/tap/domain/userWalletList/UserWalletsListManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/userWalletList/UserWalletsListManager.kt
@@ -14,17 +14,16 @@ interface UserWalletsListManager {
     val hasSavedUserWallets: Boolean
 
     suspend fun unlockWithBiometry(): CompletionResult<UserWallet?>
-    suspend fun unlockWithCard(userWallet: UserWallet): CompletionResult<Unit>
     fun lock()
 
     suspend fun selectWallet(walletId: UserWalletId): CompletionResult<UserWallet>
 
     /**
-     * Save user's wallet
-     * @param userWallet User's wallet to save
+     * Save user wallet
+     * @param userWallet [UserWallet] to save
      * @param canOverride If false, then terminate with [UserWalletListError.WalletAlreadySaved] when user tries to save an
      * already saved card
-     * @return [CompletionResult] operation result
+     * @return [CompletionResult] of operation
      * */
     suspend fun save(userWallet: UserWallet, canOverride: Boolean = false): CompletionResult<Unit>
 

--- a/app/src/main/java/com/tangem/tap/domain/userWalletList/implementation/BiometricUserWalletsListManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/userWalletList/implementation/BiometricUserWalletsListManager.kt
@@ -34,15 +34,13 @@ internal class BiometricUserWalletsListManager(
     override val selectedUserWallet: Flow<UserWallet>
         get() = state
             .mapLatest { state ->
-                state.wallets.find {
-                    it.walletId == state.selectedWalletId
-                }
+                findSelectedUserWallet(state.wallets)
             }
             .filterNotNull()
             .distinctUntilChanged()
 
     override val selectedUserWalletSync: UserWallet?
-        get() = findSelectedWallet()
+        get() = findSelectedUserWallet()
 
     override val isLocked: Flow<Boolean>
         get() = state
@@ -60,37 +58,6 @@ internal class BiometricUserWalletsListManager(
             .map { selectedUserWalletSync }
     }
 
-    override suspend fun unlockWithCard(userWallet: UserWallet): CompletionResult<Unit> {
-        state.update { prevState ->
-            // If the previous state contains a saved user wallet with the same ID, it is also saved
-            userWallet.isSaved = prevState.wallets.any {
-                it.walletId == userWallet.walletId && it.isSaved
-            }
-
-            val newEncryptionKeys = prevState.encryptionKeys
-                .plus(UserWalletEncryptionKey(userWallet))
-                .distinctBy { it.walletId }
-            val newUserWallets = prevState.wallets
-                .plus(userWallet)
-                .distinctBy { it.walletId }
-
-            prevState.copy(
-                encryptionKeys = newEncryptionKeys,
-                wallets = newUserWallets,
-                selectedWalletId = userWallet.walletId,
-            )
-        }
-
-        return loadModels()
-            .map {
-                state.update { prevState ->
-                    prevState.copy(
-                        isLocked = prevState.wallets.any { it.isLocked },
-                    )
-                }
-            }
-    }
-
     override fun lock() {
         state.update { prevState ->
             prevState.copy(
@@ -102,7 +69,7 @@ internal class BiometricUserWalletsListManager(
 
     override suspend fun selectWallet(walletId: UserWalletId): CompletionResult<UserWallet> = catching {
         if (state.value.selectedWalletId == walletId) {
-            return@catching findSelectedWallet()!!
+            return@catching findSelectedUserWallet()!!
         }
 
         if (!state.value.isLocked) {
@@ -115,41 +82,24 @@ internal class BiometricUserWalletsListManager(
             }
         }
 
-        findSelectedWallet()!!
+        findSelectedUserWallet()!!
     }
 
-    override suspend fun save(
-        userWallet: UserWallet,
-        canOverride: Boolean,
-    ): CompletionResult<Unit> = withUnlock {
-        val isWalletSaved = state.value.wallets
-            .filter { it.isSaved }
-            .any {
-                // Workaround, check [UserWallet.isTwinnedWith]
-                it.cardsInWallet.contains(userWallet.cardId) || it.isTwinnedWith(userWallet)
-            }
-
-        if (isWalletSaved && !canOverride) {
-            CompletionResult.Failure(UserWalletListError.WalletAlreadySaved)
+    override suspend fun save(userWallet: UserWallet, canOverride: Boolean): CompletionResult<Unit> {
+        return if (canOverride) {
+            saveInternal(userWallet)
         } else {
-            val newEncryptionKeys = state.value.encryptionKeys
-                .plus(UserWalletEncryptionKey(userWallet))
-                .distinctBy { it.walletId }
+            val isWalletSaved = state.value.wallets
+                .any {
+                    // Workaround, check [UserWallet.isTwinnedWith]
+                    it.cardsInWallet.contains(userWallet.cardId) || it.isTwinnedWith(userWallet)
+                }
 
-            keysRepository.store(newEncryptionKeys)
-                .doOnSuccess {
-                    state.update { prevState ->
-                        prevState.copy(
-                            encryptionKeys = newEncryptionKeys,
-                        )
-                    }
-                }
-                .flatMap { publicInformationRepository.save(userWallet) }
-                .flatMap { sensitiveInformationRepository.save(userWallet) }
-                .flatMap { loadModels() }
-                .doOnSuccess {
-                    userWallet.isSaved = true
-                }
+            if (isWalletSaved) {
+                CompletionResult.Failure(UserWalletListError.WalletAlreadySaved)
+            } else {
+                saveInternal(userWallet)
+            }
         }
     }
 
@@ -164,11 +114,11 @@ internal class BiometricUserWalletsListManager(
         val remainingEncryptionKeys = state.value.encryptionKeys
             .filter { it.walletId !in walletIdsToRemove }
 
-        changeSelectedWalletIfNeeded(walletIdsToRemove)
+        changeSelectedUserWalletIdIfNeeded(walletIdsToRemove)
 
         return sensitiveInformationRepository.delete(walletIdsToRemove)
             .flatMap { publicInformationRepository.delete(walletIdsToRemove) }
-            .flatMap { keysRepository.store(remainingEncryptionKeys) }
+            .flatMap { keysRepository.delete(walletIdsToRemove) }
             .map {
                 state.update { prevState ->
                     prevState.copy(
@@ -197,11 +147,31 @@ internal class BiometricUserWalletsListManager(
         }
     }
 
-    private suspend inline fun <reified T> withUnlock(
-        block: () -> CompletionResult<T>,
-    ): CompletionResult<T> {
-        return (if (state.value.isLocked) unlockWithBiometryInternal() else CompletionResult.Success(Unit))
-            .flatMap { block() }
+    private suspend fun saveInternal(userWallet: UserWallet): CompletionResult<Unit> {
+        val newEncryptionKeys = state.value.encryptionKeys
+            .plus(UserWalletEncryptionKey(userWallet))
+            .distinctBy { it.walletId }
+
+        return keysRepository.store(newEncryptionKeys)
+            .doOnSuccess {
+                state.update { prevState ->
+                    prevState.copy(
+                        encryptionKeys = newEncryptionKeys,
+                        selectedWalletId = userWallet.walletId,
+                    )
+                }
+            }
+            .flatMap { publicInformationRepository.save(userWallet) }
+            .flatMap { sensitiveInformationRepository.save(userWallet) }
+            .map { selectedUserWalletRepository.set(userWallet.walletId) }
+            .flatMap { loadModels() }
+            .doOnSuccess {
+                state.update { prevState ->
+                    prevState.copy(
+                        isLocked = prevState.wallets.any { it.isLocked },
+                    )
+                }
+            }
     }
 
     private suspend fun unlockWithBiometryInternal(): CompletionResult<Unit> {
@@ -231,7 +201,7 @@ internal class BiometricUserWalletsListManager(
 
                     prevState.copy(
                         wallets = wallets,
-                        selectedWalletId = findOrSetSelectedWallet(prevState.selectedWalletId, wallets),
+                        selectedWalletId = findOrSetSelectedUserWalletId(prevState.selectedWalletId, wallets),
                     )
                 }
             }
@@ -251,23 +221,20 @@ internal class BiometricUserWalletsListManager(
             }
     }
 
-    private fun findOrSetSelectedWallet(
+    private fun findOrSetSelectedUserWalletId(
         prevSelectedWalletId: UserWalletId?,
         userWallets: List<UserWallet>,
     ): UserWalletId? {
         return prevSelectedWalletId
             ?: (selectedUserWalletRepository.get()
-                ?: (userWallets.firstOrNull()?.walletId
-                    ?.also { selectedUserWalletRepository.set(it) }))
+                ?: (userWallets.firstOrNull()?.walletId?.also { selectedUserWalletRepository.set(it) }))
     }
 
-    private fun changeSelectedWalletIfNeeded(
-        walletsIdsToRemove: List<UserWalletId>,
-    ) {
+    private fun changeSelectedUserWalletIdIfNeeded(walletsIdsToRemove: List<UserWalletId>) {
         val remainingWallets = state.value.wallets.filter {
             it.walletId !in walletsIdsToRemove
         }
-        val selectedWallet = findSelectedWallet()
+        val selectedWallet = findSelectedUserWallet()
         when {
             remainingWallets.isEmpty() -> {
                 state.update { prevState ->
@@ -289,11 +256,9 @@ internal class BiometricUserWalletsListManager(
         }
     }
 
-    private fun findSelectedWallet(): UserWallet? {
-        return with(state.value) {
-            wallets.find {
-                it.walletId == selectedWalletId
-            }
+    private fun findSelectedUserWallet(userWallets: List<UserWallet> = state.value.wallets): UserWallet? {
+        return userWallets.find {
+            it.walletId == state.value.selectedWalletId
         }
     }
 

--- a/app/src/main/java/com/tangem/tap/domain/userWalletList/implementation/DummyUserWalletsListManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/userWalletList/implementation/DummyUserWalletsListManager.kt
@@ -26,10 +26,6 @@ class DummyUserWalletsListManager : UserWalletsListManager {
         return CompletionResult.Success(null)
     }
 
-    override suspend fun unlockWithCard(userWallet: UserWallet): CompletionResult<Unit> {
-        return CompletionResult.Success(Unit)
-    }
-
     override fun lock() {
         /* no-op */
     }

--- a/app/src/main/java/com/tangem/tap/domain/userWalletList/repository/UserWalletsKeysRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/userWalletList/repository/UserWalletsKeysRepository.kt
@@ -1,10 +1,36 @@
 package com.tangem.tap.domain.userWalletList.repository
 
 import com.tangem.common.CompletionResult
+import com.tangem.domain.common.util.UserWalletId
 import com.tangem.tap.domain.userWalletList.model.UserWalletEncryptionKey
 
 internal interface UserWalletsKeysRepository {
+    /**
+     * Obtaining the encryption keys of all user wallets from the biometric vault. Biometric authentication required
+     * If that operation runs more than biometric cipher key expiration time then the user will not receive all
+     * encryption keys
+     * @return [CompletionResult] of operation with stored [UserWalletEncryptionKey] list
+     * */
     suspend fun getAll(): CompletionResult<List<UserWalletEncryptionKey>>
+
+    /**
+     * Store the encryption keys for user wallets. Biometric authentication not required
+     * If one of these encryption keys is already stored, it is skipped
+     * @param encryptionKeys List of encryption keys for user wallets
+     * @return [CompletionResult] of operation
+     * */
     suspend fun store(encryptionKeys: List<UserWalletEncryptionKey>): CompletionResult<Unit>
+
+    /**
+     * Delete encryption keys for user wallets. Biometric authentication not required
+     * @param userWalletsIds List of [UserWalletId] whose encryption keys will be deleted
+     * @return [CompletionResult] of operation
+     * */
+    suspend fun delete(userWalletsIds: List<UserWalletId>): CompletionResult<Unit>
+
+    /**
+     * Clear all encryption keys for user wallets. Biometric authentication not required
+     * @return [CompletionResult] of operation
+     * */
     suspend fun clear(): CompletionResult<Unit>
 }

--- a/app/src/main/java/com/tangem/tap/domain/userWalletList/repository/implementation/BiometricUserWalletsKeysRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/userWalletList/repository/implementation/BiometricUserWalletsKeysRepository.kt
@@ -6,34 +6,40 @@ import com.squareup.moshi.Types
 import com.tangem.common.CompletionResult
 import com.tangem.common.biometric.BiometricManager
 import com.tangem.common.biometric.BiometricStorage
+import com.tangem.common.core.TangemSdkError
+import com.tangem.common.doOnFailure
 import com.tangem.common.map
 import com.tangem.common.mapFailure
 import com.tangem.common.services.secure.SecureStorage
+import com.tangem.domain.common.util.UserWalletId
 import com.tangem.tap.domain.userWalletList.UserWalletListError
 import com.tangem.tap.domain.userWalletList.model.UserWalletEncryptionKey
 import com.tangem.tap.domain.userWalletList.repository.UserWalletsKeysRepository
+import com.tangem.tap.domain.walletStores.implementation.utils.fold
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 internal class BiometricUserWalletsKeysRepository(
     moshi: Moshi,
-    secureStorage: SecureStorage,
     biometricManager: BiometricManager,
+    private val secureStorage: SecureStorage,
 ) : UserWalletsKeysRepository {
     private val biometricStorage = BiometricStorage(
         biometricManager = biometricManager,
         secureStorage = secureStorage,
     )
-    private val walletsKeysAdapter: JsonAdapter<List<UserWalletEncryptionKey>> = moshi.adapter(
-        Types.newParameterizedType(List::class.java, UserWalletEncryptionKey::class.java),
+    private val encryptionKeyAdapter: JsonAdapter<UserWalletEncryptionKey> = moshi.adapter(
+        UserWalletEncryptionKey::class.java,
     )
+    private val userWalletsIdsListAdapter: JsonAdapter<List<UserWalletId>> = moshi.adapter(
+        Types.newParameterizedType(List::class.java, UserWalletId::class.java),
+    )
+
+    private var storedUserWalletsIds: List<UserWalletId>? = null
 
     override suspend fun getAll(): CompletionResult<List<UserWalletEncryptionKey>> {
         return withContext(Dispatchers.IO) {
-            biometricStorage.get(key = StorageKey.WalletEncryptionKeys.name)
-                .map { encryptionKeys ->
-                    encryptionKeys.decodeToKeys()
-                }
+            getAllInternal()
                 .mapFailure { error ->
                     UserWalletListError.ReceiveEncryptionKeysError(error.cause ?: error)
                 }
@@ -42,40 +48,151 @@ internal class BiometricUserWalletsKeysRepository(
 
     override suspend fun store(encryptionKeys: List<UserWalletEncryptionKey>): CompletionResult<Unit> {
         return withContext(Dispatchers.IO) {
-            biometricStorage.store(
-                key = StorageKey.WalletEncryptionKeys.name,
-                data = encryptionKeys.encode(),
-            )
+            encryptionKeys.map { storeEncryptionKey(it) }
+                .fold()
                 .mapFailure { error ->
                     UserWalletListError.SaveEncryptionKeysError(error.cause ?: error)
                 }
         }
     }
 
-    override suspend fun clear(): CompletionResult<Unit> {
+    override suspend fun delete(userWalletsIds: List<UserWalletId>): CompletionResult<Unit> {
         return withContext(Dispatchers.IO) {
-            biometricStorage.delete(key = StorageKey.WalletEncryptionKeys.name)
+            userWalletsIds.map { userWalletId ->
+                deleteEncryptionKey(userWalletId)
+            }
+                .fold()
+                .map { deleteUserWalletsIds(userWalletsIds) }
         }
     }
 
-    private suspend fun List<UserWalletEncryptionKey>.encode(): ByteArray {
+    override suspend fun clear(): CompletionResult<Unit> {
+        return withContext(Dispatchers.IO) {
+            getUserWalletsIds()
+                .map { userWalletId ->
+                    deleteEncryptionKey(userWalletId)
+                }
+                .fold()
+                .map {
+                    clearUserWalletsIds()
+                }
+        }
+    }
+
+    private suspend fun getAllInternal(): CompletionResult<List<UserWalletEncryptionKey>> {
+        return getUserWalletsIds()
+            .map { userWalletId ->
+                // This is possible because the Card SDK cipher key has an expiration time
+                // If this operation runs more than that expiration time, the user will not receive all encryption keys
+                getEncryptionKey(userWalletId)
+                    .doOnFailure { error ->
+                        // If the user cancels biometric authentication, cancel the request for all keys
+                        if (error is TangemSdkError.BiometricsAuthenticationFailed) {
+                            return CompletionResult.Failure(error)
+                        }
+                    }
+            }
+            .fold(listOf()) { acc, data ->
+                if (data != null) acc + data else acc
+            }
+    }
+
+    private suspend fun getEncryptionKey(userWalletId: UserWalletId): CompletionResult<UserWalletEncryptionKey?> {
+        return biometricStorage.get(StorageKey.WalletEncryptionKey(userWalletId).name)
+            .map { it.decodeToKey() }
+    }
+
+    private suspend fun storeEncryptionKey(encryptionKey: UserWalletEncryptionKey): CompletionResult<Unit> {
+        return if (encryptionKey.walletId in getUserWalletsIds()) {
+            CompletionResult.Success(Unit)
+        } else {
+            biometricStorage.store(
+                key = StorageKey.WalletEncryptionKey(encryptionKey.walletId).name,
+                data = encryptionKey.encode(),
+            )
+                .map { storeUserWalletId(encryptionKey.walletId) }
+        }
+    }
+
+    private suspend fun deleteEncryptionKey(userWalletId: UserWalletId): CompletionResult<Unit> {
+        return biometricStorage.delete(StorageKey.WalletEncryptionKey(userWalletId).name)
+    }
+
+    private suspend fun getUserWalletsIds(): List<UserWalletId> {
+        return storedUserWalletsIds
+            ?: withContext(Dispatchers.IO) {
+                secureStorage.get(StorageKey.UserWalletIds.name)
+                    .decodeToUserWalletsIds()
+                    .also { storedUserWalletsIds = it }
+            }
+    }
+
+    private suspend fun storeUserWalletId(userWalletId: UserWalletId) {
+        val userWalletIds = (getUserWalletsIds() + userWalletId).distinct()
+        storedUserWalletsIds = userWalletIds
+
+        withContext(Dispatchers.IO) {
+            secureStorage.store(userWalletIds.encode(), StorageKey.UserWalletIds.name)
+        }
+    }
+
+    private suspend fun deleteUserWalletsIds(userWalletsIds: List<UserWalletId>) {
+        val remainingIds = (getUserWalletsIds() - userWalletsIds.toSet())
+        storedUserWalletsIds = remainingIds
+
+        withContext(Dispatchers.IO) {
+            secureStorage.store(remainingIds.encode(), StorageKey.UserWalletIds.name)
+        }
+    }
+
+    private suspend fun clearUserWalletsIds() {
+        withContext(Dispatchers.IO) {
+            secureStorage.delete(StorageKey.UserWalletIds.name)
+        }
+    }
+
+    private suspend fun UserWalletEncryptionKey.encode(): ByteArray {
         return withContext(Dispatchers.Default) {
             this@encode
-                .let(walletsKeysAdapter::toJson)
+                .let(encryptionKeyAdapter::toJson)
                 .encodeToByteArray(throwOnInvalidSequence = true)
         }
     }
 
-    private suspend fun ByteArray?.decodeToKeys(): List<UserWalletEncryptionKey> {
+    private suspend fun ByteArray?.decodeToKey(): UserWalletEncryptionKey? {
         return withContext(Dispatchers.Default) {
-            this@decodeToKeys
+            this@decodeToKey
                 ?.decodeToString(throwOnInvalidSequence = true)
-                ?.let(walletsKeysAdapter::fromJson)
+                ?.let(encryptionKeyAdapter::fromJson)
+        }
+    }
+
+    private suspend fun List<UserWalletId>.encode(): ByteArray {
+        return withContext(Dispatchers.Default) {
+            this@encode
+                .let(userWalletsIdsListAdapter::toJson)
+                .encodeToByteArray(throwOnInvalidSequence = true)
+        }
+    }
+
+    private suspend fun ByteArray?.decodeToUserWalletsIds(): List<UserWalletId> {
+        return withContext(Dispatchers.Default) {
+            this@decodeToUserWalletsIds
+                ?.decodeToString(throwOnInvalidSequence = true)
+                ?.let(userWalletsIdsListAdapter::fromJson)
                 .orEmpty()
         }
     }
 
-    private enum class StorageKey {
-        WalletEncryptionKeys
+    private sealed interface StorageKey {
+        val name: String
+
+        class WalletEncryptionKey(userWalletId: UserWalletId) : StorageKey {
+            override val name: String = "user_wallet_encryption_key_${userWalletId.stringValue}"
+        }
+
+        object UserWalletIds : StorageKey {
+            override val name: String = "user_wallets_ids_with_saved_keys"
+        }
     }
 }

--- a/app/src/main/java/com/tangem/tap/features/onboarding/OnboardingHelper.kt
+++ b/app/src/main/java/com/tangem/tap/features/onboarding/OnboardingHelper.kt
@@ -1,20 +1,16 @@
 package com.tangem.tap.features.onboarding
 
-import com.tangem.common.doOnSuccess
 import com.tangem.domain.common.ProductType
 import com.tangem.domain.common.ScanResponse
 import com.tangem.tap.common.extensions.dispatchOnMain
 import com.tangem.tap.common.extensions.onCardScanned
-import com.tangem.tap.common.extensions.onUserWalletSelected
 import com.tangem.tap.common.redux.navigation.AppScreen
 import com.tangem.tap.common.redux.navigation.NavigationAction
-import com.tangem.tap.domain.model.builders.UserWalletBuilder
 import com.tangem.tap.features.saveWallet.redux.SaveWalletAction
 import com.tangem.tap.preferencesStorage
 import com.tangem.tap.scope
 import com.tangem.tap.store
 import com.tangem.tap.tangemSdkManager
-import com.tangem.tap.userWalletsListManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -59,17 +55,6 @@ class OnboardingHelper {
             backupCardsIds: List<String>? = null,
         ) {
             when {
-                // When should save user wallets but manager is locked, then unlock manager with card
-                preferencesStorage.shouldSaveUserWallets &&
-                    userWalletsListManager.isLockedSync -> scope.launch {
-                    val userWallet = UserWalletBuilder(scanResponse).build()
-
-                    tangemSdkManager.setAccessCodeRequestPolicy(useBiometricsForAccessCode = false)
-                    userWalletsListManager.unlockWithCard(userWallet)
-                        .doOnSuccess {
-                            store.onUserWalletSelected(userWallet)
-                        }
-                }
                 // When should save user wallets, then save card without navigate to save wallet screen
                 preferencesStorage.shouldSaveUserWallets -> scope.launch {
                     store.dispatchOnMain(

--- a/app/src/main/java/com/tangem/tap/features/saveWallet/redux/SaveWalletMiddleware.kt
+++ b/app/src/main/java/com/tangem/tap/features/saveWallet/redux/SaveWalletMiddleware.kt
@@ -94,7 +94,6 @@ internal class SaveWalletMiddleware {
 
             saveAccessCodeIfNeeded(state.backupInfo?.accessCode, userWallet.cardsInWallet)
                 .flatMap { userWalletsListManager.save(userWallet, canOverride = true) }
-                .flatMap { userWalletsListManager.selectWallet(userWallet.walletId) }
                 .doOnFailure { error ->
                     store.dispatchOnMain(SaveWalletAction.Save.Error(error))
                 }
@@ -108,6 +107,7 @@ internal class SaveWalletMiddleware {
 
                     tangemSdkManager.setAccessCodeRequestPolicy(
                         useBiometricsForAccessCode = preferencesStorage.shouldSaveAccessCodes &&
+                            !userWalletsListManager.isLockedSync &&
                             userWallet.hasAccessCode,
                     )
 

--- a/app/src/main/java/com/tangem/tap/features/walletSelector/redux/WalletSelectorMiddleware.kt
+++ b/app/src/main/java/com/tangem/tap/features/walletSelector/redux/WalletSelectorMiddleware.kt
@@ -124,7 +124,11 @@ internal class WalletSelectorMiddleware {
                 .doOnFailure { error ->
                     store.dispatchOnMain(WalletSelectorAction.UnlockWithBiometry.Error(error))
                 }
-                .doOnSuccess {
+                .doOnSuccess { selectedUserWallet ->
+                    if (selectedUserWallet != null) {
+                        updateAccessCodeRequestPolicy(selectedUserWallet)
+                    }
+
                     store.dispatchOnMain(WalletSelectorAction.UnlockWithBiometry.Success)
                 }
         }
@@ -143,7 +147,6 @@ internal class WalletSelectorMiddleware {
                 .doOnSuccess {
                     Analytics.send(MyWallets.CardWasScanned)
 
-                    userWalletsListManager.selectWallet(userWallet.walletId)
                     store.dispatchOnMain(WalletSelectorAction.AddWallet.Success)
                     updateAccessCodeRequestPolicy(userWallet)
                     store.dispatchOnMain(NavigationAction.PopBackTo(AppScreen.Wallet))
@@ -199,7 +202,7 @@ internal class WalletSelectorMiddleware {
     }
 
     private suspend fun unlockUserWallet(userWallet: UserWallet): CompletionResult<Unit> {
-        return userWalletsListManager.unlockWithCard(userWallet)
+        return userWalletsListManager.save(userWallet, canOverride = true)
             .doOnSuccess {
                 store.dispatchOnMain(NavigationAction.PopBackTo(AppScreen.Wallet))
                 store.onUserWalletSelected(userWallet)

--- a/app/src/main/java/com/tangem/tap/features/walletSelector/ui/components/WallectSelectorScreenContent.kt
+++ b/app/src/main/java/com/tangem/tap/features/walletSelector/ui/components/WallectSelectorScreenContent.kt
@@ -124,7 +124,6 @@ private fun Header(
 
     Column(
         modifier = Modifier
-            .padding(horizontal = TangemTheme.dimens.spacing16)
             .fillMaxWidth()
             .background(
                 color = TangemTheme.colors.background.plain,
@@ -140,7 +139,9 @@ private fun Header(
         ) {
             if (hasEditingWallets) {
                 EditWalletsBar(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .padding(horizontal = TangemTheme.dimens.spacing16)
+                        .fillMaxWidth(),
                     editingWalletsSize = editingWalletsSize,
                     onClearSelectedClick = onClearSelectedClick,
                     onEditSelectedWalletClick = onEditSelectedWalletClick,

--- a/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeMiddleware.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeMiddleware.kt
@@ -79,7 +79,7 @@ internal class WelcomeMiddleware {
             val userWallet = UserWalletBuilder(scanResponse).build()
 
             tangemSdkManager.setAccessCodeRequestPolicy(useBiometricsForAccessCode = false)
-            userWalletsListManager.unlockWithCard(userWallet)
+            userWalletsListManager.save(userWallet, canOverride = true)
                 .doOnFailure { error ->
                     store.dispatchOnMain(WelcomeAction.ProceedWithCard.Error(error))
                 }


### PR DESCRIPTION
Теперь при сканировании карты из Welcome и из шторки, при заблокированном стейте, она будет сохраняться, так же реализованно на iOS. Надо будет получше потестить перед тем как вливать
Так же поправил мелкий баг в шторке при редактировании карт - кошельки отрисовывались за заголовком