### PR TITLE
AND-2658 Updating the WalletStores logic

### DIFF
--- a/app/src/main/java/com/tangem/tap/domain/model/TotalFiatBalance.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/TotalFiatBalance.kt
@@ -11,10 +11,6 @@ sealed class TotalFiatBalance {
 
     object Loading : TotalFiatBalance()
 
-    data class Refreshing(
-        override val amount: BigDecimal,
-    ) : TotalFiatBalance()
-
     data class Error(
         override val amount: BigDecimal,
     ) : TotalFiatBalance()

--- a/app/src/main/java/com/tangem/tap/domain/model/WalletDataModel.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/WalletDataModel.kt
@@ -35,12 +35,6 @@ data class WalletDataModel(
         open val pendingTransactions: List<PendingTransaction> = emptyList()
         open val errorMessage: String? = null
         open val isErrorStatus: Boolean = false
-
-        fun asRefreshing() = Refreshing(
-            amount = amount,
-            pendingTransactions = pendingTransactions,
-            errorMessage = errorMessage,
-        )
     }
 
     object Loading : Status()
@@ -73,13 +67,5 @@ data class WalletDataModel(
 
     object MissedDerivation : Status() {
         override val isErrorStatus: Boolean = true
-    }
-
-    data class Refreshing(
-        override val amount: BigDecimal,
-        override val pendingTransactions: List<PendingTransaction>,
-        override val errorMessage: String?,
-    ) : Status() {
-        override val isErrorStatus: Boolean = errorMessage != null
     }
 }

--- a/app/src/main/java/com/tangem/tap/domain/model/WalletStoreModel.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/WalletStoreModel.kt
@@ -1,6 +1,8 @@
 package com.tangem.tap.domain.model
 
+import com.tangem.blockchain.common.Blockchain
 import com.tangem.blockchain.common.WalletManager
+import com.tangem.common.hdWallet.DerivationPath
 import com.tangem.domain.common.util.UserWalletId
 import com.tangem.tap.domain.model.WalletStoreModel.WalletRent
 import com.tangem.tap.domain.tokens.models.BlockchainNetwork
@@ -8,21 +10,28 @@ import java.math.BigDecimal
 
 /**
  * Contains info about the blockchain and its currencies
- * @param userWalletId ID of the [UserWallet] which uses that store
- * @param blockchainNetwork Store's [BlockchainNetwork]
- * @param walletManager Store's [WalletManager], may be null if it fails to create this manager. TODO: Remove after
- * WalletMiddleware refactoring
+ * @param userWalletId ID of the associated [UserWallet]
+ * @param blockchain [Blockchain] of this WalletStore
+ * @param derivationPath [DerivationPath] of this store, null if the card does not support the
+ * [HD Wallet](https://coinsutra.com/hd-wallets-deterministic-wallet/)
  * @param walletsData List of [WalletDataModel] which represents store's blockchain currency and tokens currencies
- * @param walletRent Store's [WalletRent], null if store has no rent or currency balance is greater then
+ * @param walletRent [WalletRent], null if store has no rent or currency balance is greater then
  * [WalletRent.exemptionAmount]
+ * @param blockchainNetwork [BlockchainNetwork].
+ * TODO: Remove after WalletMiddleware refactoring
+ * @param walletManager [WalletManager], may be null if it fails to create this manager.
+ * TODO: Remove after WalletMiddleware refactoring
  * */
 data class WalletStoreModel(
     val userWalletId: UserWalletId,
+    val blockchain: Blockchain,
+    val derivationPath: DerivationPath?,
+    val walletsData: List<WalletDataModel>,
+    val walletRent: WalletRent?,
+    @Deprecated("Don't use it, will be removed")
     val blockchainNetwork: BlockchainNetwork,
     @Deprecated("Don't use it, will be removed")
     val walletManager: WalletManager?,
-    val walletsData: List<WalletDataModel>,
-    val walletRent: WalletRent?,
 ) {
 
     /**
@@ -35,4 +44,34 @@ data class WalletStoreModel(
         val rent: BigDecimal,
         val exemptionAmount: BigDecimal,
     )
+
+    // TODO: Remove the generated methods after blockchainNetwork and walletManager are removed from the model
+    // region Generated
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is WalletStoreModel) return false
+
+        if (userWalletId != other.userWalletId) return false
+        if (blockchain != other.blockchain) return false
+        if (derivationPath != other.derivationPath) return false
+        if (walletsData != other.walletsData) return false
+        if (walletRent != other.walletRent) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = userWalletId.hashCode()
+        result = 31 * result + blockchain.hashCode()
+        result = 31 * result + (derivationPath?.hashCode() ?: 0)
+        result = 31 * result + walletsData.hashCode()
+        result = 31 * result + (walletRent?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "WalletStoreModel(userWalletId=$userWalletId, blockchain=$blockchain, derivationPath=$derivationPath, " +
+            "walletsData=$walletsData, walletRent=$walletRent)"
+    }
+    // endregion Generated
 }

--- a/app/src/main/java/com/tangem/tap/domain/model/builders/WalletStoreBuilder.kt
+++ b/app/src/main/java/com/tangem/tap/domain/model/builders/WalletStoreBuilder.kt
@@ -4,6 +4,7 @@ import com.tangem.blockchain.blockchains.polkadot.ExistentialDepositProvider
 import com.tangem.blockchain.common.Blockchain
 import com.tangem.blockchain.common.Token
 import com.tangem.blockchain.common.WalletManager
+import com.tangem.common.hdWallet.DerivationPath
 import com.tangem.domain.common.util.UserWalletId
 import com.tangem.tap.domain.model.WalletDataModel
 import com.tangem.tap.domain.model.WalletStoreModel
@@ -54,10 +55,12 @@ private class BlockchainNetworkWalletStoreBuilderImpl(
 
         return WalletStoreModel(
             userWalletId = userWalletId,
-            blockchainNetwork = blockchainNetwork,
-            walletManager = walletManager,
+            blockchain = blockchainNetwork.blockchain,
+            derivationPath = blockchainNetwork.derivationPath?.let { DerivationPath(it) },
             walletsData = (listOf(blockchainWalletData) + tokensWalletsData),
             walletRent = null,
+            walletManager = walletManager,
+            blockchainNetwork = blockchainNetwork,
         )
     }
 }
@@ -74,10 +77,12 @@ private class WalletMangerWalletStoreBuilderImpl(
 
         return WalletStoreModel(
             userWalletId = userWalletId,
-            blockchainNetwork = BlockchainNetwork.fromWalletManager(walletManager),
-            walletManager = walletManager,
+            blockchain = wallet.blockchain,
+            derivationPath = wallet.publicKey.derivationPath,
             walletsData = (listOf(blockchainWalletData) + listOfNotNull(tokenWalletsData)),
             walletRent = null,
+            walletManager = walletManager,
+            blockchainNetwork = BlockchainNetwork.fromWalletManager(walletManager),
         )
     }
 }

--- a/app/src/main/java/com/tangem/tap/domain/totalBalance/implementation/DefaultTotalFiatBalanceCalculator.kt
+++ b/app/src/main/java/com/tangem/tap/domain/totalBalance/implementation/DefaultTotalFiatBalanceCalculator.kt
@@ -33,9 +33,6 @@ internal class DefaultTotalFiatBalanceCalculator : TotalFiatBalanceCalculator {
 
                 when (walletsData.findStatus()) {
                     TotalFiatBalanceStatus.Loading -> TotalFiatBalance.Loading
-                    TotalFiatBalanceStatus.Refreshing -> TotalFiatBalance.Refreshing(
-                        amount = prevAmount ?: BigDecimal.ZERO,
-                    )
                     TotalFiatBalanceStatus.Error -> TotalFiatBalance.Error(calculateAmount())
                     TotalFiatBalanceStatus.Loaded -> TotalFiatBalance.Loaded(calculateAmount())
                 }
@@ -54,7 +51,6 @@ internal class DefaultTotalFiatBalanceCalculator : TotalFiatBalanceCalculator {
     private fun Sequence<WalletDataModel>.mapToStatus(): Sequence<TotalFiatBalanceStatus> {
         return this.map { walletData ->
             when (walletData.status) {
-                is WalletDataModel.Refreshing -> TotalFiatBalanceStatus.Refreshing
                 is WalletDataModel.VerifiedOnline,
                 is WalletDataModel.SameCurrencyTransactionInProgress,
                 is WalletDataModel.TransactionInProgress,
@@ -84,18 +80,10 @@ internal class DefaultTotalFiatBalanceCalculator : TotalFiatBalanceCalculator {
     ): TotalFiatBalanceStatus {
         return when (prevStatus) {
             TotalFiatBalanceStatus.Loading -> prevStatus
-            TotalFiatBalanceStatus.Refreshing -> when (newStatus) {
-                TotalFiatBalanceStatus.Loading -> prevStatus
-                TotalFiatBalanceStatus.Refreshing,
-                TotalFiatBalanceStatus.Error,
-                TotalFiatBalanceStatus.Loaded,
-                -> newStatus
-            }
             TotalFiatBalanceStatus.Loaded,
             TotalFiatBalanceStatus.Error,
             -> when (newStatus) {
                 TotalFiatBalanceStatus.Loading,
-                TotalFiatBalanceStatus.Refreshing,
                 TotalFiatBalanceStatus.Error,
                 -> newStatus
                 TotalFiatBalanceStatus.Loaded -> prevStatus
@@ -105,7 +93,6 @@ internal class DefaultTotalFiatBalanceCalculator : TotalFiatBalanceCalculator {
 
     private enum class TotalFiatBalanceStatus {
         Loading,
-        Refreshing,
         Error,
         Loaded,
     }

--- a/app/src/main/java/com/tangem/tap/domain/walletCurrencies/implementation/DefaultWalletCurrenciesManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletCurrencies/implementation/DefaultWalletCurrenciesManager.kt
@@ -19,7 +19,6 @@ import com.tangem.tap.domain.walletStores.repository.WalletManagersRepository
 import com.tangem.tap.domain.walletStores.repository.WalletStoresRepository
 import com.tangem.tap.features.wallet.models.Currency
 import com.tangem.tap.features.wallet.models.toBlockchainNetworks
-import com.tangem.tap.features.wallet.models.toCurrencies
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -36,8 +35,8 @@ internal class DefaultWalletCurrenciesManager(
     ): CompletionResult<Unit> = withContext(Dispatchers.Default) {
         val walletStore = walletStoresRepository.getSync(userWallet.walletId)
             .find {
-                it.blockchainNetwork.blockchain == currency.blockchain
-                    && it.blockchainNetwork.derivationPath == currency.derivationPath
+                it.blockchain == currency.blockchain
+                    && it.derivationPath?.rawPath == currency.derivationPath
             }
 
         if (walletStore != null) {
@@ -102,7 +101,9 @@ internal class DefaultWalletCurrenciesManager(
     private suspend fun getSavedCurrencies(userWalletId: UserWalletId): List<Currency> {
         return withContext(Dispatchers.Default) {
             walletStoresRepository.getSync(userWalletId)
-                .flatMap { it.blockchainNetwork.toCurrencies() }
+                .flatMap { walletStore ->
+                    walletStore.walletsData.map { it.currency }
+                }
         }
     }
 
@@ -157,10 +158,9 @@ internal class DefaultWalletCurrenciesManager(
         val userWalletId = userWallet.walletId
         return blockchainNetworks
             .map { blockchainNetwork ->
-                walletManagersRepository.findOrMake(
+                walletManagersRepository.findOrMakeMultiCurrencyWalletManager(
                     userWallet = userWallet,
                     blockchainNetwork = blockchainNetwork,
-                    refresh = true,
                 )
                     .flatMap { walletManager ->
                         walletStoresRepository.storeOrUpdate(

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/implementation/DefaultWalletStoresManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/implementation/DefaultWalletStoresManager.kt
@@ -71,7 +71,7 @@ internal class DefaultWalletStoresManager(
             .mapNotNull { userWallet ->
                 val hasNotWalletStoresForUserWallet = !walletStoresRepository.contains(userWallet.walletId)
                 if (refresh || hasNotWalletStoresForUserWallet || isFiatCurrencyChanged) {
-                    fetchWalletsIfNeeded(userWallet, refresh)
+                    fetchWalletsIfNeeded(userWallet)
                 } else null
             }
             .fold(arrayListOf<UserWallet>()) { acc, data ->
@@ -102,22 +102,16 @@ internal class DefaultWalletStoresManager(
             }
     }
 
-    private suspend fun fetchWalletsIfNeeded(
-        userWallet: UserWallet,
-        refresh: Boolean,
-    ): CompletionResult<UserWallet> {
+    private suspend fun fetchWalletsIfNeeded(userWallet: UserWallet): CompletionResult<UserWallet> {
         return if (userWallet.scanResponse.card.isMultiwalletAllowed) {
-            fetchMultiWallets(userWallet, refresh)
+            fetchMultiWallets(userWallet)
         } else {
-            fetchSingleWallet(userWallet, refresh)
+            fetchSingleWallet(userWallet)
         }
             .map { userWallet }
     }
 
-    private suspend fun fetchMultiWallets(
-        userWallet: UserWallet,
-        refresh: Boolean,
-    ): CompletionResult<Unit> {
+    private suspend fun fetchMultiWallets(userWallet: UserWallet): CompletionResult<Unit> {
         val scanResponse = userWallet.scanResponse
         val userTokens = withContext(Dispatchers.IO) {
             userTokensRepository.getUserTokens(scanResponse.card)
@@ -143,10 +137,9 @@ internal class DefaultWalletStoresManager(
                             )
                         }
 
-                    walletManagersRepository.findOrMake(
+                    walletManagersRepository.findOrMakeMultiCurrencyWalletManager(
                         userWallet = userWallet,
                         blockchainNetwork = blockchainNetwork,
-                        refresh = refresh,
                     )
                         .flatMap { walletManager ->
                             storeWalletStore(walletManager)
@@ -164,13 +157,9 @@ internal class DefaultWalletStoresManager(
         }
     }
 
-    private suspend fun fetchSingleWallet(
-        userWallet: UserWallet,
-        refresh: Boolean,
-    ): CompletionResult<Unit> {
-        return walletManagersRepository.findOrMake(
+    private suspend fun fetchSingleWallet(userWallet: UserWallet): CompletionResult<Unit> {
+        return walletManagersRepository.findOrMakeSingleCurrencyWalletManager(
             userWallet = userWallet,
-            refresh = refresh,
         )
             .flatMap { walletManager ->
                 val userWalletId = userWallet.walletId

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/WalletManagersRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/WalletManagersRepository.kt
@@ -8,11 +8,12 @@ import com.tangem.tap.domain.model.UserWallet
 import com.tangem.tap.domain.tokens.models.BlockchainNetwork
 
 interface WalletManagersRepository {
-    suspend fun findOrMake(
+    suspend fun findOrMakeMultiCurrencyWalletManager(
         userWallet: UserWallet,
-        blockchainNetwork: BlockchainNetwork? = null,
-        refresh: Boolean = false,
+        blockchainNetwork: BlockchainNetwork,
     ): CompletionResult<WalletManager>
+
+    suspend fun findOrMakeSingleCurrencyWalletManager(userWallet: UserWallet): CompletionResult<WalletManager>
 
     suspend fun delete(userWalletIds: List<UserWalletId>): CompletionResult<Unit>
 

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletAmountsRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletAmountsRepository.kt
@@ -25,6 +25,7 @@ import com.tangem.tap.domain.model.WalletStoreModel
 import com.tangem.tap.domain.walletStores.WalletStoresError
 import com.tangem.tap.domain.walletStores.repository.WalletAmountsRepository
 import com.tangem.tap.domain.walletStores.repository.implementation.utils.replaceWalletStore
+import com.tangem.tap.domain.walletStores.repository.implementation.utils.replaceWalletStores
 import com.tangem.tap.domain.walletStores.repository.implementation.utils.updateWithAmounts
 import com.tangem.tap.domain.walletStores.repository.implementation.utils.updateWithError
 import com.tangem.tap.domain.walletStores.repository.implementation.utils.updateWithFiatRates
@@ -127,20 +128,10 @@ internal class DefaultWalletAmountsRepository(
 
         return when (fiatRatesResult) {
             is Result.Success -> {
-                Timber.d(
-                    """
-                        Fetched fiat rates
-                        |- User wallets ids: $walletsIds
-                        |- Coins ids: $coinsIds
-                    """.trimIndent(),
+                updateWalletStoresWithFiatRates(
+                    walletStores = walletStores,
+                    fiatRates = fiatRatesResult.data.rates,
                 )
-
-                walletStores.forEach { walletStore ->
-                    updateWalletStoreWithFiatRates(
-                        walletStore = walletStore,
-                        fiatRates = fiatRatesResult.data.rates,
-                    )
-                }
 
                 CompletionResult.Success(Unit)
             }
@@ -190,8 +181,8 @@ internal class DefaultWalletAmountsRepository(
         walletStore: WalletStoreModel,
         walletManager: WalletManager?,
     ): CompletionResult<Unit> {
-        val hasMissedDerivations = with(walletStore.blockchainNetwork) {
-            derivationPath != null && !scanResponse.hasDerivation(blockchain, derivationPath)
+        val hasMissedDerivations = with(walletStore) {
+            derivationPath != null && !scanResponse.hasDerivation(blockchain, derivationPath.rawPath)
         }
 
         return when {
@@ -200,7 +191,12 @@ internal class DefaultWalletAmountsRepository(
             else -> {
                 withInternetConnection { walletManager.update() }
                     .map { updateWalletManagerWithAmounts(walletId, walletManager) }
-                    .flatMap { updateWalletStoreWithAmounts(walletStore, walletManager.wallet) }
+                    .flatMap {
+                        updateWalletStoreWithAmounts(
+                            walletStore = walletStore,
+                            updatedWallet = walletManager.wallet,
+                        )
+                    }
                     .flatMap { fetchWalletStoreRentIfNeeded(walletStore, walletManager) }
                     .flatMapOnFailure { error ->
                         updateWalletStoreWithError(
@@ -291,16 +287,14 @@ internal class DefaultWalletAmountsRepository(
             """
                 Unable to fetch amounts
                 |- User wallet id: ${walletStore.userWalletId}
-                |- Blockchain: ${walletStore.blockchainNetwork.blockchain}
-                |- Tokens: ${walletStore.blockchainNetwork.tokens.map { it.name }}
+                |- Blockchain: ${walletStore.blockchain}
             """.trimIndent(),
         )
 
         if (error is BlockchainSdkError) {
             walletStoresStorage.update { prevState ->
                 prevState.replaceWalletStore(
-                    walletId = walletStore.userWalletId,
-                    walletStore = walletStore,
+                    walletStoreToUpdate = walletStore,
                     update = {
                         it.updateWithError(
                             wallet = wallet,
@@ -318,23 +312,21 @@ internal class DefaultWalletAmountsRepository(
 
     private suspend fun updateWalletStoreWithAmounts(
         walletStore: WalletStoreModel,
-        wallet: Wallet,
+        updatedWallet: Wallet,
     ) = withContext(Dispatchers.Default) {
         Timber.d(
             """
                 Fetched amounts
                 |- User wallet id: ${walletStore.userWalletId}
-                |- Blockchain: ${walletStore.blockchainNetwork.blockchain}
-                |- Tokens: ${walletStore.blockchainNetwork.tokens.map { it.name }}
+                |- Blockchain: ${walletStore.blockchain}
             """.trimIndent(),
         )
 
         walletStoresStorage.update { prevState ->
             prevState.replaceWalletStore(
-                walletId = walletStore.userWalletId,
-                walletStore = walletStore,
+                walletStoreToUpdate = walletStore,
                 update = {
-                    it.updateWithAmounts(wallet = wallet)
+                    it.updateWithAmounts(wallet = updatedWallet)
                 },
             )
         }
@@ -349,14 +341,13 @@ internal class DefaultWalletAmountsRepository(
             """
                 Missed derivation
                 |- User wallet id: ${walletStore.userWalletId}
-                |- Blockchain: ${walletStore.blockchainNetwork.blockchain}
+                |- Blockchain: ${walletStore.blockchain}
             """.trimIndent(),
         )
 
         walletStoresStorage.update { prevState ->
             prevState.replaceWalletStore(
-                walletId = walletStore.userWalletId,
-                walletStore = walletStore,
+                walletStoreToUpdate = walletStore,
                 update = {
                     it.updateWithMissedDerivation()
                 },
@@ -373,14 +364,13 @@ internal class DefaultWalletAmountsRepository(
             """
                 Wallet manager is null
                 |- User wallet id: ${walletStore.userWalletId}
-                |- Blockchain: ${walletStore.blockchainNetwork.blockchain}
+                |- Blockchain: ${walletStore.blockchain}
             """.trimIndent(),
         )
 
         walletStoresStorage.update { prevState ->
             prevState.replaceWalletStore(
-                walletId = walletStore.userWalletId,
-                walletStore = walletStore,
+                walletStoreToUpdate = walletStore,
                 update = {
                     it.updateWithUnreachable()
                 },
@@ -390,14 +380,20 @@ internal class DefaultWalletAmountsRepository(
         CompletionResult.Success(Unit)
     }
 
-    private suspend fun updateWalletStoreWithFiatRates(
-        walletStore: WalletStoreModel,
+    private suspend fun updateWalletStoresWithFiatRates(
+        walletStores: List<WalletStoreModel>,
         fiatRates: Map<String, Double>,
     ) = withContext(Dispatchers.Default) {
+        Timber.d(
+            """
+                Fetched fiat rates
+                |- User wallets ids: ${walletStores.map { it.userWalletId }.distinct()}
+            """.trimIndent(),
+        )
+
         walletStoresStorage.update { prevState ->
-            prevState.replaceWalletStore(
-                walletId = walletStore.userWalletId,
-                walletStore = walletStore,
+            prevState.replaceWalletStores(
+                walletStoresToUpdate = walletStores,
                 update = {
                     it.updateWithFiatRates(rates = fiatRates)
                 },
@@ -409,14 +405,24 @@ internal class DefaultWalletAmountsRepository(
         walletStore: WalletStoreModel,
         rent: WalletStoreModel.WalletRent?,
     ) = withContext(Dispatchers.Default) {
-        walletStoresStorage.update { prevState ->
-            prevState.replaceWalletStore(
-                walletId = walletStore.userWalletId,
-                walletStore = walletStore,
-                update = {
-                    it.updateWithRent(rent)
-                },
-            )
+        Timber.d(
+            """
+                Fetched wallet rent
+                |- User wallet id: ${walletStore.userWalletId}
+                |- Blockchain: ${walletStore.blockchain}
+                |- Rent: $rent
+            """.trimIndent(),
+        )
+
+        if (rent != walletStore.walletRent) {
+            walletStoresStorage.update { prevState ->
+                prevState.replaceWalletStore(
+                    walletStoreToUpdate = walletStore,
+                    update = {
+                        it.updateWithRent(rent)
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletManagersRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletManagersRepository.kt
@@ -31,26 +31,31 @@ internal class DefaultWalletManagersRepository(
 ) : WalletManagersRepository {
     private val walletManagersStorage = WalletManagerStorage
 
-    override suspend fun findOrMake(
+    override suspend fun findOrMakeMultiCurrencyWalletManager(
+        userWallet: UserWallet,
+        blockchainNetwork: BlockchainNetwork,
+    ): CompletionResult<WalletManager> {
+        return findOrMakeInternal(userWallet, blockchainNetwork)
+    }
+
+    override suspend fun findOrMakeSingleCurrencyWalletManager(userWallet: UserWallet): CompletionResult<WalletManager> {
+        return findOrMakeInternal(userWallet, blockchainNetwork = null)
+    }
+
+    private suspend fun findOrMakeInternal(
         userWallet: UserWallet,
         blockchainNetwork: BlockchainNetwork?,
-        refresh: Boolean,
     ): CompletionResult<WalletManager> = withContext(Dispatchers.Default) {
-        if (refresh) {
-            deleteInternal(userWallet.walletId, blockchainNetwork?.blockchain)
-            makeAndStore(userWallet, blockchainNetwork)
-        } else {
-            val foundWalletManager = findWalletManager(
-                userWalletId = userWallet.walletId,
-                blockchain = blockchainNetwork?.blockchain,
-            )
+        val foundWalletManager = findWalletManager(
+            userWalletId = userWallet.walletId,
+            blockchain = blockchainNetwork?.blockchain,
+        )
 
-            foundWalletManager?.updateTokens(
-                scanResponse = userWallet.scanResponse,
-                blockchainNetwork = blockchainNetwork,
-            )
-                ?: makeAndStore(userWallet, blockchainNetwork)
-        }
+        foundWalletManager?.updateTokens(
+            scanResponse = userWallet.scanResponse,
+            blockchainNetwork = blockchainNetwork,
+        )
+            ?: makeAndStore(userWallet, blockchainNetwork)
     }
 
     private suspend fun makeAndStore(
@@ -155,8 +160,11 @@ internal class DefaultWalletManagersRepository(
         return catching {
             val tokens = blockchainNetwork?.tokens ?: listOfNotNull(scanResponse.getPrimaryToken())
 
-            if (tokens.isNotEmpty()) {
-                walletManager.addTokens(tokens)
+            if (tokens != cardTokens) {
+                cardTokens.clear()
+                if (tokens.isNotEmpty()) {
+                    walletManager.cardTokens.addAll(tokens)
+                }
             }
 
             walletManager

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletStoresRepository.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/DefaultWalletStoresRepository.kt
@@ -45,11 +45,13 @@ internal class DefaultWalletStoresRepository : WalletStoresRepository {
         userWalletId: UserWalletId,
         currentBlockchains: List<Blockchain>,
     ): CompletionResult<Unit> = catching {
-        walletStoresStorage.update { prevStores ->
-            prevStores.apply {
-                this[userWalletId] = this[userWalletId]
-                    ?.filter { it.blockchainNetwork.blockchain in currentBlockchains }
-                    .orEmpty()
+        if (currentBlockchains != getSync(userWalletId).map { it.blockchain }) {
+            walletStoresStorage.update { prevStores ->
+                prevStores.apply {
+                    this[userWalletId] = this[userWalletId]
+                        ?.filter { it.blockchain in currentBlockchains }
+                        .orEmpty()
+                }
             }
         }
     }
@@ -71,32 +73,24 @@ internal class DefaultWalletStoresRepository : WalletStoresRepository {
         userWalletId: UserWalletId,
         walletStore: WalletStoreModel,
     ): HashMap<UserWalletId, List<WalletStoreModel>> = withContext(Dispatchers.Default) {
-        val prevStores = this@addOrUpdate
-        val walletStores = prevStores[userWalletId]
+        val currentWalletStores = this@addOrUpdate
+        val userWalletStores = currentWalletStores[userWalletId]
 
-        if (walletStores.isNullOrEmpty()) {
-            prevStores.apply {
+        if (userWalletStores.isNullOrEmpty()) {
+            currentWalletStores.apply {
                 set(userWalletId, listOf(walletStore))
             }
         } else {
-            val oldWalletStore = walletStores.find(walletStore::isSameWalletStore)
-
-            when {
-                oldWalletStore == null -> {
-                    prevStores.apply {
-                        set(userWalletId, walletStores + walletStore)
-                    }
+            val currentWalletStore = userWalletStores.find(walletStore::isSameWalletStore)
+            if (currentWalletStore == null) {
+                currentWalletStores.apply {
+                    set(userWalletId, userWalletStores + walletStore)
                 }
-                oldWalletStore.blockchainNetwork.tokens == walletStore.blockchainNetwork.tokens -> {
-                    prevStores
-                }
-                else -> {
-                    prevStores.replaceWalletStore(
-                        walletId = userWalletId,
-                        walletStore = oldWalletStore,
-                        update = { it.updateWithSelf(walletStore) },
-                    )
-                }
+            } else {
+                currentWalletStores.replaceWalletStore(
+                    walletStoreToUpdate = currentWalletStore,
+                    update = { it.updateWithSelf(walletStore) },
+                )
             }
         }
     }

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/utils/WalletDataOperations.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/utils/WalletDataOperations.kt
@@ -125,10 +125,9 @@ internal fun WalletDataModel.updateWithSelf(
         status = when (val newStatus = newWalletData.status) {
             is WalletDataModel.Loading -> when (oldStatus) {
                 is WalletDataModel.MissedDerivation -> WalletDataModel.Loading
-                else -> oldStatus.asRefreshing()
+                else -> oldStatus
             }
             is WalletDataModel.MissedDerivation,
-            is WalletDataModel.Refreshing,
             is WalletDataModel.NoAccount,
             is WalletDataModel.Unreachable,
             is WalletDataModel.SameCurrencyTransactionInProgress,

--- a/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/utils/WalletStoreOperations.kt
+++ b/app/src/main/java/com/tangem/tap/domain/walletStores/repository/implementation/utils/WalletStoreOperations.kt
@@ -4,16 +4,28 @@ import com.tangem.blockchain.common.Wallet
 import com.tangem.common.core.TangemError
 import com.tangem.domain.common.util.UserWalletId
 import com.tangem.tap.domain.model.WalletStoreModel
+import timber.log.Timber
 
 internal inline fun HashMap<UserWalletId, List<WalletStoreModel>>.replaceWalletStore(
-    walletId: UserWalletId,
-    walletStore: WalletStoreModel,
+    walletStoreToUpdate: WalletStoreModel,
+    update: (walletStore: WalletStoreModel) -> WalletStoreModel,
+): HashMap<UserWalletId, List<WalletStoreModel>> {
+    return replaceWalletStores(listOf(walletStoreToUpdate), update)
+}
+
+internal inline fun HashMap<UserWalletId, List<WalletStoreModel>>.replaceWalletStores(
+    walletStoresToUpdate: List<WalletStoreModel>,
     update: (walletStore: WalletStoreModel) -> WalletStoreModel,
 ): HashMap<UserWalletId, List<WalletStoreModel>> {
     return this.apply {
-        this[walletId] = this[walletId]
-            ?.replaceWalletStore(walletStore, update)
-            .orEmpty()
+        val currentWalletStores = this
+        walletStoresToUpdate
+            .groupBy { it.userWalletId }
+            .forEach { (userWalletId, walletStoresToUpdate) ->
+                currentWalletStores[userWalletId] = currentWalletStores[userWalletId]
+                    ?.replaceWalletStores(walletStoresToUpdate, update)
+                    .orEmpty()
+            }
     }
 }
 
@@ -74,20 +86,41 @@ internal fun WalletStoreModel.updateWithRent(rent: WalletStoreModel.WalletRent?)
     )
 }
 
-internal inline fun List<WalletStoreModel>.replaceWalletStore(
-    newWalletStore: WalletStoreModel,
-    update: (walletStore: WalletStoreModel) -> WalletStoreModel,
-): List<WalletStoreModel> {
-    val mutableStores = ArrayList(this)
-    for ((index, walletStore) in this.withIndex()) {
-        if (walletStore.isSameWalletStore(newWalletStore)) {
-            mutableStores[index] = update(walletStore)
-            break
-        }
-    }
-    return mutableStores
+internal fun WalletStoreModel.isSameWalletStore(other: WalletStoreModel): Boolean {
+    return this.blockchain == other.blockchain &&
+        this.derivationPath == other.derivationPath
 }
 
-internal fun WalletStoreModel.isSameWalletStore(other: WalletStoreModel): Boolean {
-    return blockchainNetwork == other.blockchainNetwork
+private inline fun List<WalletStoreModel>.replaceWalletStores(
+    walletStoresToUpdate: List<WalletStoreModel>,
+    update: (walletStore: WalletStoreModel) -> WalletStoreModel,
+): List<WalletStoreModel> {
+    val mutableStores = ArrayList<WalletStoreModel>(this)
+    mutableStores.sortBy { it.blockchain }
+
+    walletStoresToUpdate
+        .asSequence()
+        .sortedBy { it.blockchain }
+        .map { it.blockchain to it.derivationPath }
+        .forEach { (blockchain, derivationPath) ->
+            val index = mutableStores.indexOfFirst {
+                it.blockchain == blockchain && it.derivationPath == derivationPath
+            }
+            val currentWalletStore = mutableStores[index]
+            val updatedWalletStore = update(currentWalletStore)
+
+            if (currentWalletStore != updatedWalletStore) {
+                Timber.d(
+                    """
+                        Update wallet store in storage
+                        |- User wallet ID: ${updatedWalletStore.userWalletId}
+                        |- Blockchain: ${updatedWalletStore.blockchain}
+                    """.trimIndent(),
+                )
+
+                mutableStores[index] = updatedWalletStore
+            }
+        }
+
+    return mutableStores
 }

--- a/app/src/main/java/com/tangem/tap/features/wallet/redux/WalletAction.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/redux/WalletAction.kt
@@ -209,8 +209,6 @@ sealed class WalletAction : Action {
     data class WalletStoresChanged(val walletStores: List<WalletStoreModel>) : WalletAction() {
         data class UpdateWalletStores(
             val reduxWalletStores: List<WalletStore>,
-            val reduxWalletData: List<WalletData>,
-            val selectedWalletData: WalletData?,
         ) : WalletAction()
     }
 

--- a/app/src/main/java/com/tangem/tap/features/wallet/redux/middlewares/Mapper.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/redux/middlewares/Mapper.kt
@@ -22,9 +22,9 @@ import com.tangem.tap.features.wallet.ui.BalanceWidgetData
 import com.tangem.tap.features.wallet.ui.TokenData
 import com.tangem.tap.store
 
-internal fun Sequence<WalletStoreModel>.mapToReduxModels(
+internal fun List<WalletStoreModel>.mapToReduxModels(
     isMultiWalletAllowed: Boolean,
-): Sequence<WalletStore> {
+): List<WalletStore> {
     return this.map { walletStoreModel ->
         walletStoreModel.mapToReduxModel(isMultiWalletAllowed)
     }
@@ -34,7 +34,6 @@ internal fun TotalFiatBalance.mapToReduxModel(): TotalBalance {
     return TotalBalance(
         state = when (this) {
             is TotalFiatBalance.Loading -> ProgressState.Loading
-            is TotalFiatBalance.Refreshing -> ProgressState.Refreshing
             is TotalFiatBalance.Error -> ProgressState.Error
             is TotalFiatBalance.Loaded -> ProgressState.Done
         },
@@ -96,7 +95,6 @@ private fun List<WalletDataModel>.mapToReduxModel(
                     status = when (status) {
                         is WalletDataModel.Loading -> BalanceStatus.Loading
                         is WalletDataModel.NoAccount -> BalanceStatus.NoAccount
-                        is WalletDataModel.Refreshing -> BalanceStatus.Refreshing
                         is WalletDataModel.SameCurrencyTransactionInProgress -> BalanceStatus.SameCurrencyTransactionInProgress
                         is WalletDataModel.TransactionInProgress -> BalanceStatus.TransactionInProgress
                         is WalletDataModel.Unreachable -> BalanceStatus.Unreachable

--- a/app/src/main/java/com/tangem/tap/features/wallet/redux/middlewares/WalletMiddleware.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/redux/middlewares/WalletMiddleware.kt
@@ -308,16 +308,11 @@ class WalletMiddleware {
 
     private fun updateWalletStores(wallStores: List<WalletStoreModel>, state: WalletState) {
         scope.launch(Dispatchers.Default) {
-            val reduxWalletStores = wallStores.asSequence().mapToReduxModels(state.isMultiwalletAllowed)
-            val reduxWalletsData = reduxWalletStores.flatMap { it.walletsData }
-            val selectedWalletData = reduxWalletsData
-                .find { it.currency == state.selectedWalletData?.currency }
+            val reduxWalletStores = wallStores.mapToReduxModels(state.isMultiwalletAllowed)
 
             store.dispatchOnMain(
                 WalletAction.WalletStoresChanged.UpdateWalletStores(
                     reduxWalletStores = reduxWalletStores.toList(),
-                    reduxWalletData = reduxWalletsData.toList(),
-                    selectedWalletData = selectedWalletData,
                 ),
             )
         }

--- a/app/src/main/java/com/tangem/tap/features/wallet/redux/reducers/WalletReducer.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/redux/reducers/WalletReducer.kt
@@ -20,6 +20,7 @@ import com.tangem.tap.domain.extensions.isMultiwalletAllowed
 import com.tangem.tap.domain.getFirstToken
 import com.tangem.tap.domain.tokens.models.BlockchainNetwork
 import com.tangem.tap.features.wallet.models.Currency
+import com.tangem.tap.features.wallet.models.TotalBalance
 import com.tangem.tap.features.wallet.models.WalletRent
 import com.tangem.tap.features.wallet.redux.AddressData
 import com.tangem.tap.features.wallet.redux.Artwork
@@ -35,6 +36,7 @@ import com.tangem.tap.features.wallet.redux.replaceSomeWalletsData
 import com.tangem.tap.features.wallet.ui.BalanceStatus
 import com.tangem.tap.features.wallet.ui.BalanceWidgetData
 import com.tangem.tap.proxy.AppStateHolder
+import com.tangem.tap.store
 import org.rekotlin.Action
 import timber.log.Timber
 import java.math.BigDecimal
@@ -344,13 +346,16 @@ private fun internalReduce(action: Action, state: AppState, appStateHolder: AppS
                     card.settings.isBackupAllowed &&
                     card.backupStatus == CardDTO.BackupStatus.NoBackup,
                 walletCardsCount = card.findCardsCount(),
+                totalBalance = if (card.isMultiwalletAllowed) {
+                    TotalBalance(ProgressState.Loading, BigDecimal.ZERO, store.state.globalState.appCurrency)
+                } else {
+                    null
+                },
             )
         }
         is WalletAction.WalletStoresChanged.UpdateWalletStores -> {
             newState = newState.copy(
                 walletsStores = action.reduxWalletStores,
-                // walletsDataCopyFromStore = action.reduxWalletData,
-                selectedCurrency = action.selectedWalletData?.currency,
             )
         }
         is WalletAction.TotalFiatBalanceChanged -> {

--- a/app/src/main/java/com/tangem/tap/features/wallet/ui/wallet/MultiWalletView.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/ui/wallet/MultiWalletView.kt
@@ -37,9 +37,10 @@ class MultiWalletView : WalletView() {
 
     private val watcher = modelWatcher<WalletState> {
         val totalBalanceStrategy: DiffStrategy<WalletState> = { old, new ->
-            old.totalBalance != new.totalBalance ||
+            old.cardId != new.cardId ||
+                old.totalBalance != new.totalBalance ||
                 old.state != new.state ||
-                old.walletsDataFromStores.size != new.walletsDataFromStores.size
+                old.walletsStores.size != new.walletsStores.size
         }
 
         (WalletState::walletsStores or WalletState::state) { walletState ->

--- a/app/src/main/res/layout/layout_card_total_balance.xml
+++ b/app/src/main/res/layout/layout_card_total_balance.xml
@@ -12,8 +12,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="18dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="18dp"
-        android:animateLayoutChanges="true">
+        android:layout_marginBottom="18dp">
 
         <TextView
             android:id="@+id/tv_title"


### PR DESCRIPTION
- Убрал Refresh стейт для `WalletDataModel` и `TotalFiatBalance` 
- Разбил метод поиска и создания WalletManager'ов на 2: один для одновалютных, второй для мультивалютный менеджеров
- Обновил логку проверки изменений для записи в `WalletStoresStorage`
- Обновил поведение баланса кошелька при смене кошелька

Сейчас стабильно наблюдается баг, что при первой загрузке WalletStore для кошелька у последнего загруженного WalletStore не убирается шиммер, несмотря на то, что у него статус `VerifiedOnline`