### PR TITLE
AND-2036 Fix background card scan

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,10 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.tangem.wallet">
 
-    <uses-feature
-        android:name="android.hardware.nfc"
-        android:required="true" />
-
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -19,6 +15,9 @@
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="true" />
 
     <queries>
         <intent>
@@ -51,46 +50,48 @@
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
 
                 <data
+                    android:pathPrefix="/ndef"
                     android:host="www.tangem.com"
                     android:scheme="http" />
                 <data
+                    android:pathPrefix="/ndef"
                     android:host="www.tangem.com"
                     android:scheme="https" />
                 <data
+                    android:pathPrefix="/ndef"
                     android:host="tangem.com"
                     android:scheme="http" />
                 <data
+                    android:pathPrefix="/ndef"
                     android:host="tangem.com"
                     android:scheme="https" />
                 <data
+                    android:pathPrefix="/ndef"
                     android:host="app.tangem.com"
                     android:scheme="https" />
             </intent-filter>
 
             <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:host="ext"
-                    android:pathPrefix="/android.com:pkg"
-                    android:scheme="vnd.android.nfc" />
-            </intent-filter>
-
-            <intent-filter>
                 <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
             <meta-data
                 android:name="android.nfc.action.TECH_DISCOVERED"
                 android:resource="@xml/nfc_tech_filter" />
+
+            <intent-filter>
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/tangem/tap/common/IntentHandler.kt
+++ b/app/src/main/java/com/tangem/tap/common/IntentHandler.kt
@@ -3,17 +3,32 @@ package com.tangem.tap.common
 import android.content.Intent
 import android.nfc.NfcAdapter
 import android.nfc.Tag
+import android.os.Build
 import com.tangem.tap.common.extensions.removePrefixOrNull
-import com.tangem.tap.common.redux.navigation.AppScreen
-import com.tangem.tap.common.redux.navigation.NavigationAction
 import com.tangem.tap.domain.walletconnect.WalletConnectManager
 import com.tangem.tap.features.details.redux.walletconnect.WalletConnectAction
 import com.tangem.tap.features.home.redux.HomeAction
 import com.tangem.tap.features.wallet.redux.WalletAction
+import com.tangem.tap.features.welcome.redux.WelcomeAction
+import com.tangem.tap.scope
 import com.tangem.tap.store
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class IntentHandler {
+
+    private val nfcActions = arrayOf(
+        NfcAdapter.ACTION_NDEF_DISCOVERED,
+        NfcAdapter.ACTION_TECH_DISCOVERED,
+        NfcAdapter.ACTION_TAG_DISCOVERED,
+    )
+
+    fun handleIntent(intent: Intent?, hasSavedUserWallets: Boolean) {
+        handleBackgroundScan(intent, hasSavedUserWallets)
+        handleWalletConnectLink(intent)
+        handleSellCurrencyCallback(intent)
+    }
 
     fun handleWalletConnectLink(intent: Intent?) {
         val wcUri = when (intent?.scheme) {
@@ -32,19 +47,29 @@ class IntentHandler {
         }
     }
 
-    fun handleBackgroundScan(intent: Intent?) {
-        if (intent != null && (NfcAdapter.ACTION_TECH_DISCOVERED == intent.action ||
-            NfcAdapter.ACTION_NDEF_DISCOVERED == intent.action
-            )
-        ) {
-            val tag = intent.getParcelableExtra<Tag>(NfcAdapter.EXTRA_TAG)
-            if (tag != null) {
-                intent.action = null
-                store.dispatch(NavigationAction.NavigateTo(AppScreen.Home))
-                store.dispatch(NavigationAction.PopBackTo(AppScreen.Home))
-                store.dispatch(HomeAction.ReadCard())
-            }
+    fun handleBackgroundScan(intent: Intent?, hasSavedUserWallets: Boolean): Boolean {
+        if (intent == null || intent.action !in nfcActions) return false
+
+        val tag: Tag? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
         }
+        if (tag == null) return false
+
+        intent.action = null
+        if (hasSavedUserWallets) {
+            // TODO: Remove delay after https://tangem.atlassian.net/browse/AND-2840
+            scope.launch {
+                delay(timeMillis = 200)
+                store.dispatch(WelcomeAction.ProceedWithCard)
+            }
+        } else {
+            store.dispatch(HomeAction.ReadCard())
+        }
+
+        return true
     }
 
     fun handleSellCurrencyCallback(intent: Intent?) {

--- a/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeAction.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeAction.kt
@@ -15,7 +15,7 @@ internal sealed interface WelcomeAction : Action {
         data class Error(val error: TangemError) : WelcomeAction
     }
 
-    data class HandleDeepLink(val intent: Intent?) : WelcomeAction
+    data class HandleIntentIfNeeded(val intent: Intent?) : WelcomeAction
 
     object CloseError : WelcomeAction
 }

--- a/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeReducer.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeReducer.kt
@@ -12,7 +12,7 @@ internal object WelcomeReducer {
 
     private fun internalReduce(action: WelcomeAction, state: WelcomeState): WelcomeState {
         return when (action) {
-            is WelcomeAction.HandleDeepLink -> state.copy(deepLinkIntent = action.intent)
+            is WelcomeAction.HandleIntentIfNeeded -> state.copy(intent = action.intent)
             is WelcomeAction.ProceedWithBiometrics -> state.copy(isUnlockWithBiometricsInProgress = true)
             is WelcomeAction.ProceedWithCard -> state.copy(isUnlockWithCardInProgress = true)
             is WelcomeAction.ProceedWithBiometrics.Error -> state.copy(

--- a/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeState.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/redux/WelcomeState.kt
@@ -7,6 +7,6 @@ import org.rekotlin.StateType
 data class WelcomeState(
     val isUnlockWithBiometricsInProgress: Boolean = false,
     val isUnlockWithCardInProgress: Boolean = false,
-    val deepLinkIntent: Intent? = null,
+    val intent: Intent? = null,
     val error: TangemError? = null,
 ) : StateType

--- a/app/src/main/res/xml/nfc_tech_filter.xml
+++ b/app/src/main/res/xml/nfc_tech_filter.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <tech-list>
         <tech>android.nfc.tech.IsoDep</tech>
-        <tech>android.nfc.tech.Ndef</tech>
+        <tech>android.nfc.tech.NfcA</tech>
         <tech>android.nfc.tech.NfcV</tech>
+        <tech>android.nfc.tech.Ndef</tech>
     </tech-list>
 </resources>


### PR DESCRIPTION
Для тестов убрал суффикс из ID приложения

Сканирование карты со свернутым/закрытым приложением:

https://user-images.githubusercontent.com/26351057/214613038-0a2f1ff8-6ac4-4be0-b035-9b06526caa55.mp4

Работа WalletConnect (вроде ничего не сломалось):

https://user-images.githubusercontent.com/26351057/214613148-529086ea-b57e-443f-a33b-e376aaaf834d.mp4


Это не полноценный фикс этого бага, основная проблемма в прошивке карты. Но если раньше Pixel вообще отказывался сканировать карту при выключенном приложении, то теперь бывает сканирует. Так же допилил логику при сканировании карты из бекграунда при включенном сохранении кошельков