### PR TITLE
AND-3289 Reset dialog state after dismissing dialog with UTXO amount warning description (reopen)

### DIFF
--- a/app/src/main/java/com/tangem/tap/features/send/ui/dialogs/KaspaWarningDialog.kt
+++ b/app/src/main/java/com/tangem/tap/features/send/ui/dialogs/KaspaWarningDialog.kt
@@ -2,7 +2,6 @@ package com.tangem.tap.features.send.ui.dialogs
 
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
-import com.tangem.tap.common.extensions.dispatchDialogHide
 import com.tangem.tap.features.send.redux.SendAction
 import com.tangem.tap.store
 import com.tangem.wallet.R
@@ -22,7 +21,7 @@ object KaspaWarningDialog {
                 dialog.onOk()
             }
             setOnDismissListener {
-                store.dispatchDialogHide()
+                store.dispatch(SendAction.Dialog.Hide)
             }
         }
             .create()


### PR DESCRIPTION
Переоткрыли баг, оказывется `store.dispatchDialogHide()` и `store.dispatch(SendAction.Dialog.Hide)` разные вещи делают