### PR TITLE
AND-3273 refresh wallet data when connection found

### DIFF
--- a/app/src/main/java/com/tangem/tap/features/wallet/ui/WalletViewModel.kt
+++ b/app/src/main/java/com/tangem/tap/features/wallet/ui/WalletViewModel.kt
@@ -80,14 +80,6 @@ internal class WalletViewModel @Inject constructor(
         analyticsEventHandler.send(MainScreen.ScreenOpened())
     }
 
-    private fun launch() {
-        val manager = store.state.globalState.userWalletsListManager
-        if (manager != null) {
-            bootstrapSelectedWalletStoresChanges(manager)
-        }
-        bootstrapShowSaveWalletIfNeeded()
-    }
-
     fun onBalanceLoaded(totalBalance: TotalFiatBalance?) {
         if (totalBalance != null) {
             walletAnalyticsEventsMapper.convert(totalBalance)?.let { balanceParam ->
@@ -98,6 +90,14 @@ internal class WalletViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    private fun launch() {
+        val manager = store.state.globalState.userWalletsListManager
+        if (manager != null) {
+            bootstrapSelectedWalletStoresChanges(manager)
+        }
+        bootstrapShowSaveWalletIfNeeded()
     }
 
     @OptIn(FlowPreview::class)

--- a/core/datasource/src/main/java/com/tangem/datasource/connection/AndroidNetworkConnectionManager.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/connection/AndroidNetworkConnectionManager.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -35,11 +36,12 @@ internal class AndroidNetworkConnectionManager @Inject constructor(
     private val dispatchers: CoroutineDispatcherProvider,
 ) : NetworkConnectionManager {
 
-    override val isOnline: Boolean get() = _isOnline.value
-
     private val _isOnline = MutableStateFlow(value = false)
     private val callbacks = NetworkConnectionManagerCallbacks()
     private val receiver = NetworkConnectionBroadcastReceiver()
+
+    override val isOnline: Boolean get() = _isOnline.value
+    override val isOnlineFlow: StateFlow<Boolean> = _isOnline
 
     init {
         (context as? Application)?.registerActivityLifecycleCallbacks(callbacks)

--- a/core/datasource/src/main/java/com/tangem/datasource/connection/NetworkConnectionManager.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/connection/NetworkConnectionManager.kt
@@ -1,8 +1,13 @@
 package com.tangem.datasource.connection
 
+import kotlinx.coroutines.flow.StateFlow
+
 /** Network connection manager */
 interface NetworkConnectionManager {
 
     /** Connection status */
     val isOnline: Boolean
+
+    /** Connection status flow */
+    val isOnlineFlow: StateFlow<Boolean>
 }


### PR DESCRIPTION
Слушаем изменения сети и обновляется state экрана при появлении сети.
Пришлось прихранить стейт была ли ошибка сети при загрузке, также слушается NetworkConnectionManager во фрагменте. Вынести это во ViewModel не вышло, т.к. потребуется перенос всего стейта туда и подписка модели вместо фрагмента, это скорее имеет смысл делать либо в рамках рефакторинга, либо уже новую главную сделать сразу без этого.