### PR TITLE
bugfix/AND-3761 Crash after opening the app on Android 6

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         android:fullBackupContent="false"
         android:networkSecurityConfig="@xml/network_security_config"
         android:hardwareAccelerated="true"
+        android:largeHeap="@bool/largeHeap"
         tools:ignore="GoogleAppIndexingWarning"
         tools:replace="android:allowBackup, android:fullBackupContent">
 

--- a/app/src/main/res/values-v24/bool.xml
+++ b/app/src/main/res/values-v24/bool.xml
@@ -1,0 +1,5 @@
+<resources>
+
+    <bool name="largeHeap">false</bool>
+
+</resources>

--- a/app/src/main/res/values/bool.xml
+++ b/app/src/main/res/values/bool.xml
@@ -1,0 +1,5 @@
+<resources>
+
+    <bool name="largeHeap">true</bool>
+
+</resources>


### PR DESCRIPTION
largeHeap is set to true for devices with 21 <= sdkVersion <= 23