### PR TITLE
AND-3869 Set extractNativeLibs flag to true.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         android:largeHeap="@bool/largeHeap"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher"
+        android:extractNativeLibs="true"
         android:supportsRtl="true"
         tools:ignore="GoogleAppIndexingWarning"
         tools:replace="android:allowBackup, android:fullBackupContent">


### PR DESCRIPTION
**Вкратце про суть изменений**
при выставлении minSdk 23 или выше (что случилось у нас в приложении пару недель назад вместе с добавлением WC 2.0) андроид неявно убирает механизм компрессии so-файлов внутри apk

**Терминология** 
старинка — minSdk < 23
новинка — minSdk >= 23, никакие новые доп. флаги не выставлены

**Если по старинке, то плюсы и минусы**
`+` сжатая сошка в апк => апк занимает меньше места

`-` требуется некоторое время на распаковку сошки из apk в system/data (происходит при установке/обновлении, не при запуске приложения — это важно)
`-` если сравнивать старинку и новинку, то суммарно по занимаемому месту в сторадже size(apk + extracted_so) > size(apk)


**А по новинке всё наоборот**
`+` не надо ничего распаковывать при установке
`+` size(apk) < size(apk + extracted_so)

`-` апк занимает больше места, что и произошло в нашем случае



Пока на скорую руку решили сделать такой фикс, но на самом деле есть нюансы, с которыми можно ознакомиться здесь
https://medium.com/androiddevelopers/smallerapk-part-8-native-libraries-open-from-apk-fc22713861ff

Я бы подождал появления 4.7 в сторе, посмотрел бы насколько внутренние механизмы стора умеют сжимать размер (студия говорит, что может, и весьма неплохо :))
<img width="307" alt="image" src="https://github.com/tangem/tangem-app-android/assets/13484957/04890ae8-fa64-48d9-a92d-7c5d2768140b">

и принимал бы решение о том, заливать этот PR или нет, основываясь на количестве мегабайт, которые мы фактически загружаем из стора

