### PR TITLE
AND-4512: prevent crash on MainActivity recreation in CardSdkProvider

### DIFF
--- a/app/src/main/java/com/tangem/tap/features/details/redux/DetailsAction.kt
+++ b/app/src/main/java/com/tangem/tap/features/details/redux/DetailsAction.kt
@@ -1,6 +1,7 @@
 package com.tangem.tap.features.details.redux
 
 import com.tangem.core.ui.extensions.TextReference
+import androidx.lifecycle.LifecycleCoroutineScope
 import com.tangem.domain.apptheme.model.AppThemeMode
 import com.tangem.domain.common.CardTypesResolver
 import com.tangem.domain.models.scan.CardDTO
@@ -72,6 +73,7 @@ sealed class DetailsAction : Action {
 
         data class CheckBiometricsStatus(
             val awaitStatusChange: Boolean,
+            val lifecycleCoroutineScope: LifecycleCoroutineScope,
         ) : AppSettings()
 
         object EnrollBiometrics : AppSettings()

--- a/app/src/main/java/com/tangem/tap/features/details/redux/DetailsMiddleware.kt
+++ b/app/src/main/java/com/tangem/tap/features/details/redux/DetailsMiddleware.kt
@@ -1,5 +1,6 @@
 package com.tangem.tap.features.details.redux
 
+import androidx.lifecycle.LifecycleCoroutineScope
 import com.tangem.common.CompletionResult
 import com.tangem.common.core.TangemError
 import com.tangem.common.core.TangemSdkError
@@ -193,7 +194,11 @@ class DetailsMiddleware {
                     }
                 }
                 is DetailsAction.AppSettings.CheckBiometricsStatus -> {
-                    checkBiometricsStatus(action.awaitStatusChange, state)
+                    checkBiometricsStatus(
+                        awaitStatusChange = action.awaitStatusChange,
+                        state = state,
+                        lifecycleScope = action.lifecycleCoroutineScope,
+                    )
                 }
                 is DetailsAction.AppSettings.EnrollBiometrics -> {
                     enrollBiometrics()
@@ -212,8 +217,12 @@ class DetailsMiddleware {
          * @param awaitStatusChange If true then start a new coroutine and check the biometric status every 100
          * milliseconds until it changes
          * */
-        private fun checkBiometricsStatus(awaitStatusChange: Boolean, state: DetailsState) {
-            scope.launch {
+        private fun checkBiometricsStatus(
+            awaitStatusChange: Boolean,
+            state: DetailsState,
+            lifecycleScope: LifecycleCoroutineScope,
+        ) {
+            lifecycleScope.launch {
                 if (awaitStatusChange) {
                     while (state.appSettingsState.needEnrollBiometrics == tangemSdkManager.needEnrollBiometrics) {
                         delay(timeMillis = 100)

--- a/app/src/main/java/com/tangem/tap/features/details/ui/appsettings/AppSettingsFragment.kt
+++ b/app/src/main/java/com/tangem/tap/features/details/ui/appsettings/AppSettingsFragment.kt
@@ -3,6 +3,7 @@ package com.tangem.tap.features.details.ui.appsettings
 import android.os.Bundle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import androidx.transition.TransitionInflater
 import com.tangem.core.navigation.NavigationAction
 import com.tangem.core.ui.screen.ComposeFragment
@@ -38,7 +39,7 @@ internal class AppSettingsFragment : ComposeFragment(), StoreSubscriber<DetailsS
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        viewModel.checkBiometricsStatus()
+        viewModel.checkBiometricsStatus(lifecycleScope)
     }
 
     override fun TransitionInflater.inflateTransitions(): Boolean {
@@ -59,7 +60,7 @@ internal class AppSettingsFragment : ComposeFragment(), StoreSubscriber<DetailsS
 
     override fun onResume() {
         super.onResume()
-        viewModel.refreshBiometricsStatus()
+        viewModel.refreshBiometricsStatus(lifecycleScope)
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/tangem/tap/features/details/ui/appsettings/AppSettingsViewModel.kt
+++ b/app/src/main/java/com/tangem/tap/features/details/ui/appsettings/AppSettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.tangem.tap.features.details.ui.appsettings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.LifecycleCoroutineScope
 import com.tangem.domain.apptheme.model.AppThemeMode
 import com.tangem.tap.common.extensions.dispatchOnMain
 import com.tangem.tap.common.redux.AppState
@@ -30,12 +31,22 @@ internal class AppSettingsViewModel(private val store: Store<AppState>) {
         )
     }
 
-    fun checkBiometricsStatus() {
-        store.dispatch(DetailsAction.AppSettings.CheckBiometricsStatus(awaitStatusChange = false))
+    fun checkBiometricsStatus(lifecycleScope: LifecycleCoroutineScope) {
+        store.dispatch(
+            DetailsAction.AppSettings.CheckBiometricsStatus(
+                awaitStatusChange = false,
+                lifecycleCoroutineScope = lifecycleScope,
+            ),
+        )
     }
 
-    fun refreshBiometricsStatus() {
-        store.dispatch(DetailsAction.AppSettings.CheckBiometricsStatus(awaitStatusChange = true))
+    fun refreshBiometricsStatus(lifecycleScope: LifecycleCoroutineScope) {
+        store.dispatch(
+            DetailsAction.AppSettings.CheckBiometricsStatus(
+                awaitStatusChange = true,
+                lifecycleCoroutineScope = lifecycleScope,
+            ),
+        )
     }
 
     private fun buildItems(state: AppSettingsState): ImmutableList<AppSettingsScreenState.Item> {

--- a/data/card/src/main/java/com/tangem/data/card/sdk/DefaultCardSdkProvider.kt
+++ b/data/card/src/main/java/com/tangem/data/card/sdk/DefaultCardSdkProvider.kt
@@ -20,26 +20,18 @@ import javax.inject.Singleton
 internal class DefaultCardSdkProvider @Inject constructor() : CardSdkProvider, CardSdkLifecycleObserver {
 
     override val sdk: TangemSdk
-        get() = requireNotNull(value = _sdk) { "Impossible to get the TangemSdk when activity is destroyed" }
+        get() = requireNotNull(value = _sdk?.get()) { "Impossible to get the TangemSdk when activity is destroyed" }
 
-    private var _sdk: TangemSdk? = null
-
-    /** Weak reference of context that uses to create [TangemSdk] */
-    private var contextRef: WeakReference<Context> = WeakReference(null)
+    private var _sdk: WeakReference<TangemSdk?>? = null
 
     override fun onCreate(context: Context) {
-        contextRef = WeakReference(context)
-        _sdk = TangemSdk.initWithBiometrics(activity = context as FragmentActivity, config = config)
+        _sdk = WeakReference(TangemSdk.initWithBiometrics(activity = context as FragmentActivity, config = config))
     }
 
     override fun onDestroy(context: Context) {
-        /*
-         * Check if the context is the same as the one that created the [TangemSdk].
-         * If so, clear the [TangemSdk]. Otherwise, the [TangemSdk] have already been created for another activity.
-         */
-        if (contextRef.get() == context) {
-            _sdk = null
-        }
+        // Commented out to prevent crash on getting sdk when it's null.
+        // FIXME: We still should find the real cause and fix it properly.
+        // _sdk = null
     }
 
     private companion object {


### PR DESCRIPTION
Временный фикс в том, чтобы не обнулять TangemSdk в onDestroy. SDK обернуто в weak reference и переопределяется при создании новой активити, поэтому не должно особо сильно утечь. При этом краш при пересоздании активити пропадает.