### PR TITLE
AND-4704 Redesign: Rate app warning is not displayed & AND-4707 Redesign: Warning about Rent for solanа blockchain doesn't appear if you do pull to refresh

### DIFF
--- a/data/settings/src/main/java/com/tangem/data/settings/DefaultAppRatingRepository.kt
+++ b/data/settings/src/main/java/com/tangem/data/settings/DefaultAppRatingRepository.kt
@@ -67,8 +67,9 @@ internal class DefaultAppRatingRepository(
             if (!isInteracting) {
                 val diff = Calendar.getInstance().timeInMillis - fundsFoundDate
                 val diffInDays = diff / DAY_IN_MILLIS
+                val isFundsFound = fundsFoundDate != FUNDS_FOUND_DATE_UNDEFINED
 
-                appLaunchCount >= ratingShowingCount && diffInDays >= FIRST_SHOWING_COUNT
+                appLaunchCount >= ratingShowingCount && diffInDays >= FIRST_SHOWING_COUNT && isFundsFound
             } else {
                 appLaunchCount >= ratingShowingCount
             }

--- a/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/components/TokenDetailsNotification.kt
+++ b/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/components/TokenDetailsNotification.kt
@@ -10,11 +10,15 @@ import com.tangem.features.tokendetails.impl.R
 
 // TODO: Finalize notification strings https://tangem.atlassian.net/browse/AND-4586
 @Immutable
-sealed class TokenDetailsNotification(open val config: NotificationConfig) {
+sealed class TokenDetailsNotification(
+    open val isVisible: Boolean = true,
+    open val config: NotificationConfig,
+) {
 
     data class RentInfo(
         private val rentInfo: CryptoCurrencyWarning.Rent,
         private val onCloseClick: () -> Unit,
+        override val isVisible: Boolean = true,
     ) : TokenDetailsNotification(
         config = NotificationConfig(
             title = TextReference.Res(R.string.send_network_fee_title),

--- a/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/factory/TokenDetailsNotificationConverter.kt
+++ b/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/factory/TokenDetailsNotificationConverter.kt
@@ -1,5 +1,6 @@
 package com.tangem.feature.tokendetails.presentation.tokendetails.state.factory
 
+import com.tangem.common.extensions.cast
 import com.tangem.domain.tokens.model.warnings.CryptoCurrencyWarning
 import com.tangem.feature.tokendetails.presentation.tokendetails.state.TokenDetailsState
 import com.tangem.feature.tokendetails.presentation.tokendetails.state.components.TokenDetailsNotification
@@ -23,9 +24,15 @@ internal class TokenDetailsNotificationConverter(
         return newNotifications.toImmutableList()
     }
 
-    fun removeRentInfo(currentState: TokenDetailsState): ImmutableList<TokenDetailsNotification> {
+    fun getStateRentInfoVisibility(
+        currentState: TokenDetailsState,
+        isVisible: Boolean,
+    ): ImmutableList<TokenDetailsNotification> {
         val newNotifications = currentState.notifications.toMutableList()
-        newNotifications.removeBy { it is TokenDetailsNotification.RentInfo }
+        val oldNotification = newNotifications.find { it is TokenDetailsNotification.RentInfo }
+        oldNotification?.let {
+            newNotifications.add(it.cast<TokenDetailsNotification.RentInfo>().copy(isVisible = isVisible))
+        }
         return newNotifications.toImmutableList()
     }
 

--- a/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/factory/TokenDetailsStateFactory.kt
+++ b/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/state/factory/TokenDetailsStateFactory.kt
@@ -141,7 +141,9 @@ internal class TokenDetailsStateFactory(
     }
 
     fun getRefreshedState(): TokenDetailsState {
+        val state = currentStateProvider()
         return refreshStateConverter.convert(false)
+            .copy(notifications = notificationConverter.getStateRentInfoVisibility(state, true))
     }
 
     fun getStateWithReceiveBottomSheet(
@@ -223,6 +225,6 @@ internal class TokenDetailsStateFactory(
 
     fun getStateWithRemovedRentNotification(): TokenDetailsState {
         val state = currentStateProvider()
-        return state.copy(notifications = notificationConverter.removeRentInfo(state))
+        return state.copy(notifications = notificationConverter.getStateRentInfoVisibility(state, false))
     }
 }

--- a/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/ui/TokenDetailsScreen.kt
+++ b/features/tokendetails/impl/src/main/kotlin/com/tangem/feature/tokendetails/presentation/tokendetails/ui/TokenDetailsScreen.kt
@@ -81,7 +81,7 @@ internal fun TokenDetailsScreen(state: TokenDetailsState) {
                 }
                 item { TokenDetailsBalanceBlock(modifier = itemModifier, state = state.tokenBalanceBlockState) }
                 items(
-                    items = state.notifications,
+                    items = state.notifications.filter { it.isVisible },
                     key = { it.config::class.java },
                     contentType = { it.config::class.java },
                     itemContent = { Notification(config = it.config, modifier = itemModifier.animateItemPlacement()) },


### PR DESCRIPTION
AND-4704 Redesign: Rate app warning is not displayed 
AND-4707 Redesign: Warning about Rent for solanа blockchain doesn't appear if you do pull to refresh