### PR TITLE
AND-4710 AND-4701 AND-4702 AND-4703 redesign signed transactions warning fix

### DIFF
--- a/data/card/src/main/java/com/tangem/data/card/DefaultCardRepository.kt
+++ b/data/card/src/main/java/com/tangem/data/card/DefaultCardRepository.kt
@@ -4,6 +4,7 @@ import com.tangem.datasource.local.card.UsedCardInfo
 import com.tangem.datasource.local.card.UsedCardsStore
 import com.tangem.domain.card.repository.CardRepository
 import com.tangem.utils.coroutines.CoroutineDispatcherProvider
+import com.tangem.utils.extensions.addOrReplace
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
@@ -42,12 +43,7 @@ internal class DefaultCardRepository(
     }
 
     private fun List<UsedCardInfo>.updateCard(cardId: String): List<UsedCardInfo> {
-        return map { cardInfo ->
-            if (cardInfo.cardId == cardId) {
-                cardInfo.copy(isScanned = true)
-            } else {
-                cardInfo
-            }
-        }
+        val card = find { it.cardId == cardId } ?: UsedCardInfo(cardId = cardId, isScanned = true)
+        return addOrReplace(item = card.copy(isScanned = true), predicate = { it.cardId == cardId })
     }
 }

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/WalletAlertState.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/WalletAlertState.kt
@@ -5,9 +5,6 @@ import com.tangem.core.ui.extensions.TextReference
 
 @Immutable
 internal sealed class WalletAlertState {
-
-    data class WalletAlreadySignedHashes(val onUnderstandClick: () -> Unit) : WalletAlertState()
-
     data class DefaultAlert(
         val title: TextReference,
         val message: TextReference,

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/WalletEvent.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/WalletEvent.kt
@@ -20,7 +20,5 @@ internal sealed class WalletEvent {
 
     data class CopyAddress(val address: String) : WalletEvent()
 
-    data class ShowWalletAlreadySignedHashesMessage(val onUnderstandClick: () -> Unit) : WalletEvent()
-
     data class RateApp(val onDismissClick: () -> Unit) : WalletEvent()
 }

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/components/WalletNotification.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/state/components/WalletNotification.kt
@@ -57,6 +57,7 @@ sealed class WalletNotification(val config: NotificationConfig) {
         subtitle: TextReference,
         buttonsState: NotificationConfig.ButtonsState? = null,
         onClick: (() -> Unit)? = null,
+        onCloseClick: (() -> Unit)? = null,
     ) : WalletNotification(
         config = NotificationConfig(
             title = title,
@@ -64,6 +65,7 @@ sealed class WalletNotification(val config: NotificationConfig) {
             iconResId = R.drawable.img_attention_20,
             buttonsState = buttonsState,
             onClick = onClick,
+            onCloseClick = onCloseClick,
         ),
     ) {
 
@@ -91,15 +93,10 @@ sealed class WalletNotification(val config: NotificationConfig) {
             subtitle = stringReference(value = errorMessage),
         )
 
-        object NumberOfSignedHashesIncorrect : Warning(
+        data class NumberOfSignedHashesIncorrect(val onCloseClick: () -> Unit) : Warning(
             title = resourceReference(id = R.string.common_warning),
             subtitle = resourceReference(id = R.string.alert_card_signed_transactions),
-        )
-
-        data class MultiWalletSignedHashesIncorrect(val onClick: () -> Unit) : Warning(
-            title = resourceReference(id = R.string.common_warning),
-            subtitle = resourceReference(id = R.string.warning_signed_tx_previously),
-            onClick = onClick,
+            onCloseClick = onCloseClick,
         )
     }
 

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/ui/WalletAlert.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/ui/WalletAlert.kt
@@ -11,30 +11,10 @@ import com.tangem.feature.wallet.presentation.wallet.state.WalletAlertState
 @Composable
 internal fun WalletAlert(config: WalletAlertState, onDismiss: () -> Unit) {
     when (config) {
-        is WalletAlertState.WalletAlreadySignedHashes -> {
-            WalletAlreadySignedHashesAlert(config = config, onDismiss = onDismiss)
-        }
         is WalletAlertState.DefaultAlert -> {
             DefaultAlert(config = config, onDismiss = onDismiss)
         }
     }
-}
-
-@Composable
-private fun WalletAlreadySignedHashesAlert(config: WalletAlertState.WalletAlreadySignedHashes, onDismiss: () -> Unit) {
-    BasicDialog(
-        message = stringResource(id = R.string.alert_signed_hashes_message),
-        confirmButton = DialogButton(
-            title = stringResource(id = R.string.common_understand),
-            onClick = {
-                config.onUnderstandClick()
-                onDismiss()
-            },
-        ),
-        onDismissDialog = onDismiss,
-        title = stringResource(id = R.string.warning_important_security_info, "\u26A0"),
-        dismissButton = DialogButton(title = stringResource(id = R.string.common_cancel), onClick = onDismiss),
-    )
 }
 
 @Composable

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/ui/WalletEventEffect.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/ui/WalletEventEffect.kt
@@ -47,11 +47,6 @@ internal fun WalletEventEffect(
                 is WalletEvent.CopyAddress -> {
                     clipboardManager.setText(AnnotatedString(value.address))
                 }
-                is WalletEvent.ShowWalletAlreadySignedHashesMessage -> {
-                    onAlertConfigSet(
-                        WalletAlertState.WalletAlreadySignedHashes(onUnderstandClick = value.onUnderstandClick),
-                    )
-                }
                 is WalletEvent.ShowAlert -> {
                     onAlertConfigSet(
                         WalletAlertState.DefaultAlert(

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletClickIntents.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletClickIntents.kt
@@ -17,6 +17,8 @@ internal interface WalletClickIntents {
 
     fun onBackupCardClick()
 
+    fun onSignedHashesNotificationCloseClick()
+
     fun onLikeAppClick()
 
     fun onDislikeAppClick()

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletClickIntents.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletClickIntents.kt
@@ -17,8 +17,6 @@ internal interface WalletClickIntents {
 
     fun onBackupCardClick()
 
-    fun onMultiWalletSignedHashesNotificationClick()
-
     fun onLikeAppClick()
 
     fun onDislikeAppClick()

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletNotificationsListFactory.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletNotificationsListFactory.kt
@@ -149,8 +149,14 @@ internal class WalletNotificationsListFactory(
             }
 
             addIf(
-                element = WalletNotification.Warning.NumberOfSignedHashesIncorrect,
-                condition = checkSignedHashes(cardTypesResolver, isDemo, wasCardScanned),
+                element = WalletNotification.Warning.NumberOfSignedHashesIncorrect(
+                    onCloseClick = clickIntents::onSignedHashesNotificationCloseClick,
+                ),
+                condition = checkSignedHashes(
+                    cardTypesResolver = cardTypesResolver,
+                    isDemo = isDemo,
+                    wasCardScanned = wasCardScanned,
+                ),
             )
         }
     }
@@ -171,13 +177,16 @@ internal class WalletNotificationsListFactory(
             ?.errorMessage
     }
 
+    /**
+     * Warning is being shown for single wallet cards only
+     */
     private fun checkSignedHashes(
         cardTypesResolver: CardTypesResolver,
         isDemo: Boolean,
         wasCardScanned: Boolean,
     ): Boolean {
-        return cardTypesResolver.isReleaseFirmwareType() && cardTypesResolver.hasWalletSignedHashes() && !isDemo &&
-            !wasCardScanned
+        return cardTypesResolver.isReleaseFirmwareType() && !cardTypesResolver.isTangemTwins() &&
+            cardTypesResolver.hasWalletSignedHashes() && !isDemo && !wasCardScanned
     }
 
     private companion object {

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletNotificationsListFactory.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletNotificationsListFactory.kt
@@ -137,28 +137,6 @@ internal class WalletNotificationsListFactory(
                 element = WalletNotification.Warning.SomeNetworksUnreachable,
                 condition = cryptoCurrencyList.hasUnreachableNetworks(),
             )
-
-            if (cardTypesResolver.isBackupForbidden()) {
-                addIf(
-                    element = WalletNotification.Warning.NumberOfSignedHashesIncorrect,
-                    condition = checkSignedHashes(
-                        cardTypesResolver = cardTypesResolver,
-                        isDemo = isDemo,
-                        wasCardScanned,
-                    ),
-                )
-            } else {
-                addIf(
-                    element = WalletNotification.Warning.MultiWalletSignedHashesIncorrect(
-                        onClick = clickIntents::onMultiWalletSignedHashesNotificationClick,
-                    ),
-                    condition = checkSignedHashes(
-                        cardTypesResolver = cardTypesResolver,
-                        isDemo = isDemo,
-                        wasCardScanned,
-                    ),
-                )
-            }
         } else {
             addIf(
                 element = WalletNotification.Warning.NetworksUnreachable,

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletViewModel.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletViewModel.kt
@@ -406,6 +406,15 @@ internal class WalletViewModel @Inject constructor(
         router.openOnboardingScreen()
     }
 
+    override fun onSignedHashesNotificationCloseClick() {
+        val state = uiState as? WalletState.ContentState ?: return
+        viewModelScope.launch(dispatchers.main) {
+            setCardWasScannedUseCase(
+                cardId = getWallet(index = state.walletsListConfig.selectedWalletIndex).cardId,
+            )
+        }
+    }
+
     override fun onLikeAppClick() {
         analyticsEventsHandler.send(WalletScreenAnalyticsEvent.NoticeRateAppButton(AnalyticsParam.RateApp.Liked))
         uiState = stateFactory.getStateAndTriggerEvent(

--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletViewModel.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/wallet/viewmodels/WalletViewModel.kt
@@ -406,24 +406,6 @@ internal class WalletViewModel @Inject constructor(
         router.openOnboardingScreen()
     }
 
-    override fun onMultiWalletSignedHashesNotificationClick() {
-        val state = uiState as? WalletState.ContentState ?: return
-
-        uiState = stateFactory.getStateAndTriggerEvent(
-            state = uiState,
-            event = WalletEvent.ShowWalletAlreadySignedHashesMessage(
-                onUnderstandClick = {
-                    viewModelScope.launch(dispatchers.main) {
-                        setCardWasScannedUseCase(
-                            cardId = getWallet(index = state.walletsListConfig.selectedWalletIndex).cardId,
-                        )
-                    }
-                },
-            ),
-            setUiState = { uiState = it },
-        )
-    }
-
     override fun onLikeAppClick() {
         analyticsEventsHandler.send(WalletScreenAnalyticsEvent.NoticeRateAppButton(AnalyticsParam.RateApp.Liked))
         uiState = stateFactory.getStateAndTriggerEvent(


### PR DESCRIPTION
AND-4701 Redesign: warning that the card has previously signed transactions is displayed for twin cards
AND-4702 Redesign: warning that the card has previously signed transactions is displayed for wallet cards
AND-4703 Redesign: remove the warning that the card signed transactions for old multi-currency cards
AND-4710 Redesign: it is impossible to hide the warning that the card has previously signed transactions (single-currency cards)
