### PR TITLE
AND-6160 AND-6165 [Wallet] Fixed duplication of requests for saving the currency list order

### DIFF
--- a/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/organizetokens/OrganizeTokensViewModel.kt
+++ b/features/wallet/impl/src/main/java/com/tangem/feature/wallet/presentation/organizetokens/OrganizeTokensViewModel.kt
@@ -147,9 +147,7 @@ internal class OrganizeTokensViewModel @Inject constructor(
                 ifLeft = stateHolder::updateStateWithError,
                 ifRight = {
                     stateHolder.updateStateToHideProgress()
-                    withContext(
-                        dispatchers.main,
-                    ) { router.popBackStack() }
+                    withContext(dispatchers.main) { router.popBackStack() }
                 },
             )
         }


### PR DESCRIPTION
Cейчас при использовании `GetTokenListUseCase` нет возможности понять, что загрузка списка валют завершена, и поэтому при добавлении дерваций запрос на обновление сортировки будет отправляться при загрузке каждой сети у которой не было деривации, при условии, что порядок изменился.
Пример: У пользователя 10 сетей, но у четырех нет деривации, и после того, как он их сделает запрос отправиться до четырех раз, а может вообще не отправится, если сортировка не изменилась.
Что-бы это поправить, надо добавить `LceState` (или что-то подобное) для use case'а (https://tangem.atlassian.net/browse/AND-6218), но это не хочется тащить в релиз.