### PR TITLE
AND-6770 Create AssetLoader

### DIFF
--- a/app/src/main/java/com/tangem/tap/ApplicationEntryPoint.kt
+++ b/app/src/main/java/com/tangem/tap/ApplicationEntryPoint.kt
@@ -4,7 +4,7 @@ import com.tangem.TangemSdkLogger
 import com.tangem.blockchainsdk.BlockchainSDKFactory
 import com.tangem.core.analytics.filter.OneTimeEventFilter
 import com.tangem.core.featuretoggle.manager.FeatureTogglesManager
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.config.ConfigManager
 import com.tangem.datasource.connection.NetworkConnectionManager
 import com.tangem.datasource.local.token.UserTokensStore
@@ -27,11 +27,11 @@ import com.tangem.features.managetokens.featuretoggles.ManageTokensFeatureToggle
 import com.tangem.features.send.api.featuretoggles.SendFeatureToggles
 import com.tangem.tap.domain.walletconnect2.domain.WalletConnectSessionsRepository
 import com.tangem.tap.features.customtoken.api.featuretoggles.CustomTokenFeatureToggles
-import com.tangem.tap.domain.walletconnect2.domain.WalletConnectRepository as WalletConnect2Repository
 import com.tangem.tap.proxy.AppStateHolder
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import com.tangem.tap.domain.walletconnect2.domain.WalletConnectRepository as WalletConnect2Repository
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/tangem/tap/TangemApplication.kt
+++ b/app/src/main/java/com/tangem/tap/TangemApplication.kt
@@ -18,7 +18,7 @@ import com.tangem.core.analytics.filter.OneTimeEventFilter
 import com.tangem.core.featuretoggle.manager.FeatureTogglesManager
 import com.tangem.datasource.api.common.MoshiConverter
 import com.tangem.datasource.api.common.createNetworkLoggingInterceptor
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.config.ConfigManager
 import com.tangem.datasource.config.FeaturesLocalLoader
 import com.tangem.datasource.config.models.Config

--- a/app/src/main/java/com/tangem/tap/di/domain/WalletManagersFacadeModule.kt
+++ b/app/src/main/java/com/tangem/tap/di/domain/WalletManagersFacadeModule.kt
@@ -2,7 +2,7 @@ package com.tangem.tap.di.domain
 
 import com.squareup.moshi.Moshi
 import com.tangem.blockchainsdk.BlockchainSDKFactory
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.di.SdkMoshi
 import com.tangem.datasource.local.userwallet.UserWalletsStore
 import com.tangem.datasource.local.walletmanager.WalletManagersStore

--- a/app/src/main/java/com/tangem/tap/domain/twins/TwinCardsManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/twins/TwinCardsManager.kt
@@ -88,6 +88,7 @@ class TwinCardsManager(
             )
         }
 
+        @Deprecated(message = "Use AssetReader instead")
         private fun getIssuers(reader: AssetReader): List<Issuer> {
             val file = reader.readJson(fileName = "tangem-app-config/issuers")
             return getAdapter().fromJson(file)!!

--- a/app/src/main/java/com/tangem/tap/domain/twins/TwinCardsManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/twins/TwinCardsManager.kt
@@ -9,7 +9,7 @@ import com.tangem.common.KeyPair
 import com.tangem.common.extensions.hexToBytes
 import com.tangem.common.extensions.toHexString
 import com.tangem.datasource.api.common.MoshiConverter
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.domain.models.scan.CardDTO
 import com.tangem.domain.models.scan.ScanResponse
 import com.tangem.operations.wallet.CreateWalletResponse

--- a/app/src/main/java/com/tangem/tap/features/onboarding/products/twins/redux/TwinCardsAction.kt
+++ b/app/src/main/java/com/tangem/tap/features/onboarding/products/twins/redux/TwinCardsAction.kt
@@ -3,7 +3,7 @@ package com.tangem.tap.features.onboarding.products.twins.redux
 import com.tangem.Message
 import com.tangem.blockchain.common.WalletManager
 import com.tangem.common.extensions.VoidCallback
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.domain.models.scan.ScanResponse
 import com.tangem.tap.domain.TapError
 import com.tangem.tap.domain.twins.TwinCardsManager

--- a/app/src/main/java/com/tangem/tap/features/onboarding/products/twins/ui/OnboardingTwinsFragment.kt
+++ b/app/src/main/java/com/tangem/tap/features/onboarding/products/twins/ui/OnboardingTwinsFragment.kt
@@ -15,7 +15,7 @@ import com.tangem.common.extensions.VoidCallback
 import com.tangem.core.analytics.Analytics
 import com.tangem.core.navigation.ShareElement
 import com.tangem.core.ui.extensions.setStatusBarColor
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.domain.common.TwinCardNumber
 import com.tangem.domain.models.scan.ScanResponse
 import com.tangem.domain.userwallets.Artwork

--- a/core/datasource/src/main/java/com/tangem/datasource/asset/loader/AssetLoader.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/asset/loader/AssetLoader.kt
@@ -1,0 +1,87 @@
+package com.tangem.datasource.asset.loader
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import com.tangem.datasource.asset.reader.AssetReader
+import com.tangem.datasource.di.NetworkMoshi
+import com.tangem.utils.coroutines.CoroutineDispatcherProvider
+import com.tangem.utils.coroutines.runCatching
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Asset file loader
+ *
+ * @author Andrew Khokhlov on 11/04/2024
+ */
+class AssetLoader @Inject constructor(
+    val assetReader: AssetReader,
+    @NetworkMoshi val moshi: Moshi,
+    val dispatchers: CoroutineDispatcherProvider,
+) {
+
+    /** Load content [Content] of asset file [fileName] */
+    @OptIn(ExperimentalStdlibApi::class)
+    suspend inline fun <reified Content> load(fileName: String): Content? {
+        return runCatching(dispatchers.io) {
+            val json = assetReader.readJson(fileName = fileName)
+
+            moshi.adapter<Content>().fromJson(json)
+        }
+            .fold(
+                onSuccess = { parsedConfig ->
+                    if (parsedConfig == null) Timber.e(IllegalStateException("Parsed config is null"))
+                    parsedConfig
+                },
+                onFailure = {
+                    Timber.e(it, "Failed to load config from assets")
+                    null
+                },
+            )
+    }
+
+    /** Load list [V] values of asset file [fileName] */
+    suspend inline fun <reified V> loadList(fileName: String): List<V> {
+        return runCatching(dispatchers.io) {
+            val json = assetReader.readJson(fileName = fileName)
+
+            val type = Types.newParameterizedType(List::class.java, V::class.java)
+            val adapter = moshi.adapter<List<V>>(type)
+
+            adapter.fromJson(json)
+        }
+            .fold(
+                onSuccess = { parsedConfig ->
+                    if (parsedConfig == null) Timber.e(IllegalStateException("Parsed config is null"))
+                    parsedConfig.orEmpty()
+                },
+                onFailure = {
+                    Timber.e(it, "Failed to load config from assets")
+                    emptyList()
+                },
+            )
+    }
+
+    /** Load map [String] keys and [V] values of asset file [fileName] */
+    suspend inline fun <reified V> loadMap(fileName: String): Map<String, V> {
+        return runCatching(dispatchers.io) {
+            val json = assetReader.readJson(fileName = fileName)
+
+            val type = Types.newParameterizedType(Map::class.java, String::class.java, V::class.java)
+            val adapter = moshi.adapter<Map<String, V>>(type)
+
+            adapter.fromJson(json)
+        }
+            .fold(
+                onSuccess = { parsedConfig ->
+                    if (parsedConfig == null) Timber.e(IllegalStateException("Parsed config is null"))
+                    parsedConfig.orEmpty()
+                },
+                onFailure = {
+                    Timber.e(it, "Failed to load config from assets")
+                    emptyMap()
+                },
+            )
+    }
+}

--- a/core/datasource/src/main/java/com/tangem/datasource/asset/reader/AndroidAssetReader.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/asset/reader/AndroidAssetReader.kt
@@ -1,4 +1,4 @@
-package com.tangem.datasource.asset
+package com.tangem.datasource.asset.reader
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/core/datasource/src/main/java/com/tangem/datasource/asset/reader/AssetReader.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/asset/reader/AssetReader.kt
@@ -1,4 +1,4 @@
-package com.tangem.datasource.asset
+package com.tangem.datasource.asset.reader
 
 import java.io.InputStream
 

--- a/core/datasource/src/main/java/com/tangem/datasource/config/FeaturesLocalLoader.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/config/FeaturesLocalLoader.kt
@@ -11,6 +11,7 @@ import timber.log.Timber
 /**
  * Created by Anton Zhilenkov on 16/02/2021.
  */
+@Deprecated(message = "Use AssetReader instead")
 class FeaturesLocalLoader(
     private val assetReader: AssetReader,
     private val moshi: Moshi,

--- a/core/datasource/src/main/java/com/tangem/datasource/config/FeaturesLocalLoader.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/config/FeaturesLocalLoader.kt
@@ -2,7 +2,7 @@ package com.tangem.datasource.config
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.config.models.ConfigModel
 import com.tangem.datasource.config.models.ConfigValueModel
 import com.tangem.datasource.config.models.FeatureModel

--- a/core/datasource/src/main/java/com/tangem/datasource/di/AssetModule.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/di/AssetModule.kt
@@ -1,7 +1,7 @@
 package com.tangem.datasource.di
 
-import com.tangem.datasource.asset.AndroidAssetReader
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AndroidAssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/core/datasource/src/main/java/com/tangem/datasource/di/TestnetTokensStorageModule.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/di/TestnetTokensStorageModule.kt
@@ -2,7 +2,7 @@ package com.tangem.datasource.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.local.testnet.DefaultTestnetTokensStorage
 import com.tangem.datasource.local.testnet.TestnetTokensStorage
 import dagger.Module

--- a/core/datasource/src/main/java/com/tangem/datasource/local/testnet/DefaultTestnetTokensStorage.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/local/testnet/DefaultTestnetTokensStorage.kt
@@ -17,6 +17,7 @@ internal class DefaultTestnetTokensStorage(
     private val adapter: JsonAdapter<TestnetTokensConfig>,
 ) : TestnetTokensStorage {
 
+    @Deprecated(message = "Use AssetReader instead")
     override fun getConfig(): TestnetTokensConfig {
         return requireNotNull(
             value = adapter.fromJson(

--- a/core/datasource/src/main/java/com/tangem/datasource/local/testnet/DefaultTestnetTokensStorage.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/local/testnet/DefaultTestnetTokensStorage.kt
@@ -1,7 +1,7 @@
 package com.tangem.datasource.local.testnet
 
 import com.squareup.moshi.JsonAdapter
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.local.testnet.models.TestnetTokensConfig
 
 /**

--- a/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/di/FeatureTogglesManagerModule.kt
+++ b/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/di/FeatureTogglesManagerModule.kt
@@ -10,7 +10,7 @@ import com.tangem.core.featuretoggle.manager.ProdFeatureTogglesManager
 import com.tangem.core.featuretoggle.storage.LocalFeatureTogglesStorage
 import com.tangem.core.featuretoggle.version.DefaultVersionProvider
 import com.tangem.core.featuretoggles.BuildConfig
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.local.preferences.AppPreferencesStore
 import dagger.Module
 import dagger.Provides

--- a/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorage.kt
+++ b/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorage.kt
@@ -3,7 +3,7 @@ package com.tangem.core.featuretoggle.storage
 import androidx.annotation.VisibleForTesting
 import com.squareup.moshi.JsonAdapter
 import com.tangem.core.featuretoggle.storage.LocalFeatureTogglesStorage.Companion.LOCAL_CONFIG_PATH
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import timber.log.Timber
 import kotlin.properties.Delegates
 

--- a/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorage.kt
+++ b/core/featuretoggles/src/main/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorage.kt
@@ -24,6 +24,7 @@ internal class LocalFeatureTogglesStorage(
     override var featureToggles: List<FeatureToggle> by Delegates.notNull()
         private set
 
+    @Deprecated(message = "Use AssetReader instead")
     override suspend fun init() {
         runCatching { requireNotNull(jsonAdapter.fromJson(assetReader.readJson(LOCAL_CONFIG_PATH))) }
             .onSuccess { featureToggles = it }

--- a/core/featuretoggles/src/test/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorageTest.kt
+++ b/core/featuretoggles/src/test/kotlin/com/tangem/core/featuretoggle/storage/LocalFeatureTogglesStorageTest.kt
@@ -3,12 +3,11 @@ package com.tangem.core.featuretoggle.storage
 import android.annotation.SuppressLint
 import com.google.common.truth.Truth
 import com.squareup.moshi.JsonAdapter
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verifyAll
 import io.mockk.verifyOrder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.io.IOException
@@ -16,7 +15,6 @@ import java.io.IOException
 /**
  * @author Andrew Khokhlov on 15/03/2023
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 @SuppressLint("CheckResult")
 internal class LocalFeatureTogglesStorageTest {
 

--- a/domain/legacy/src/main/java/com/tangem/domain/walletmanager/DefaultWalletManagersFacade.kt
+++ b/domain/legacy/src/main/java/com/tangem/domain/walletmanager/DefaultWalletManagersFacade.kt
@@ -19,7 +19,7 @@ import com.tangem.blockchain.extensions.SimpleResult
 import com.tangem.blockchainsdk.BlockchainSDKFactory
 import com.tangem.crypto.bip39.Mnemonic
 import com.tangem.crypto.hdWallet.DerivationPath
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.local.userwallet.UserWalletsStore
 import com.tangem.datasource.local.walletmanager.WalletManagersStore
 import com.tangem.domain.common.util.hasDerivation

--- a/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionHistoryItemConverter.kt
+++ b/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionHistoryItemConverter.kt
@@ -2,7 +2,7 @@ package com.tangem.domain.walletmanager.utils
 
 import com.squareup.moshi.Moshi
 import com.tangem.blockchain.common.txhistory.TransactionHistoryItem
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.domain.txhistory.models.TxHistoryItem
 import com.tangem.utils.converter.Converter
 import com.tangem.blockchain.common.txhistory.TransactionHistoryItem as SdkTransactionHistoryItem

--- a/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionTypeConverter.kt
+++ b/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionTypeConverter.kt
@@ -40,6 +40,7 @@ class SdkTransactionTypeConverter(
         }
     }
 
+    @Deprecated(message = "Use AssetReader instead")
     private fun readSmartContractMethods(): Map<String, SmartContractMethod> {
         val json = assetReader.readJson("contract_methods")
         return adapter.fromJson(json) ?: emptyMap()

--- a/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionTypeConverter.kt
+++ b/domain/legacy/src/main/java/com/tangem/domain/walletmanager/utils/SdkTransactionTypeConverter.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import com.tangem.blockchain.common.txhistory.TransactionHistoryItem
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.domain.txhistory.models.TxHistoryItem
 import com.tangem.domain.walletmanager.model.SmartContractMethod
 import com.tangem.utils.converter.Converter

--- a/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/di/BlockchainSDKFactoryModule.kt
+++ b/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/di/BlockchainSDKFactoryModule.kt
@@ -11,7 +11,7 @@ import com.tangem.blockchainsdk.loader.ConfigLoader
 import com.tangem.blockchainsdk.loader.LocalConfigLoader
 import com.tangem.datasource.api.common.AuthProvider
 import com.tangem.datasource.api.tangemTech.TangemTechApi
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.di.SdkMoshi
 import com.tangem.datasource.local.preferences.AppPreferencesStore
 import com.tangem.libs.blockchain_sdk.BuildConfig

--- a/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/loader/LocalConfigLoader.kt
+++ b/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/loader/LocalConfigLoader.kt
@@ -29,6 +29,7 @@ internal class LocalConfigLoader(
     @OptIn(ExperimentalStdlibApi::class)
     private val adapter: JsonAdapter<ConfigValueModel> = moshi.adapter()
 
+    @Deprecated(message = "Use AssetReader instead")
     override suspend fun load(): ConfigValueModel? {
         return runCatching(dispatchers.io) {
             val json = assetReader.readJson(fileName = configFileName)

--- a/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/loader/LocalConfigLoader.kt
+++ b/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/loader/LocalConfigLoader.kt
@@ -3,7 +3,7 @@ package com.tangem.blockchainsdk.loader
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
-import com.tangem.datasource.asset.AssetReader
+import com.tangem.datasource.asset.reader.AssetReader
 import com.tangem.datasource.config.models.ConfigValueModel
 import com.tangem.utils.coroutines.CoroutineDispatcherProvider
 import com.tangem.utils.coroutines.runCatching


### PR DESCRIPTION
Получилось много файлов из-за переноса AssetReader из одного пакета в другой. По сути это просто импорты.
Первый коммит – перенос.
Второй коммит – добавил новый компонент + задеприкейтил бойлер плейт методы