### PR TITLE
AND-6968 Fixed subscriptions on welcome screen.

### DIFF
--- a/app/src/main/java/com/tangem/tap/features/welcome/ui/WelcomeViewModel.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/ui/WelcomeViewModel.kt
@@ -31,7 +31,6 @@ internal class WelcomeViewModel @Inject constructor(
     private val stateInternal = MutableStateFlow(WelcomeScreenState())
     val state: StateFlow<WelcomeScreenState> = stateInternal
 
-
     override fun onCreate(owner: LifecycleOwner) {
         store.dispatch(WelcomeAction.SetCoroutineScope(viewModelScope))
 

--- a/app/src/main/java/com/tangem/tap/features/welcome/ui/WelcomeViewModel.kt
+++ b/app/src/main/java/com/tangem/tap/features/welcome/ui/WelcomeViewModel.kt
@@ -31,14 +31,13 @@ internal class WelcomeViewModel @Inject constructor(
     private val stateInternal = MutableStateFlow(WelcomeScreenState())
     val state: StateFlow<WelcomeScreenState> = stateInternal
 
-    init {
+
+    override fun onCreate(owner: LifecycleOwner) {
         store.dispatch(WelcomeAction.SetCoroutineScope(viewModelScope))
 
         subscribeToStoreChanges()
         initGlobalState()
-    }
 
-    override fun onCreate(owner: LifecycleOwner) {
         val welcomeAction = if (initialIntent != null) {
             WelcomeAction.ProceedWithIntent(initialIntent)
         } else {
@@ -81,9 +80,10 @@ internal class WelcomeViewModel @Inject constructor(
         }
     }
 
-    override fun onCleared() {
+    override fun onDestroy(owner: LifecycleOwner) {
         store.dispatch(WelcomeAction.ClearCoroutineScope)
         store.unsubscribe(this)
+        super.onDestroy(owner)
     }
 
     private fun createWarningIfNeeded(error: TangemError?): WarningModel? {


### PR DESCRIPTION
По всей видимости из-за этого в течение последнего года мы периодически наблюдали трудновоспроизводимый баг с полумертвым стейтом

Подписка на биометрию была активна даже после перехода на главный, и отлуп биометрии вызывал чистку userwallet'ов, в связи с чем приложение не могло их получить, а текущий user wallet id нужен чуть ли не во всех сценариях приложения