### PR TITLE
AND-7685 Fix bugs on CardSettings and RefactorToSettings after refactoring

### DIFF
--- a/app/src/main/java/com/tangem/tap/domain/sdk/TangemSdkManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/sdk/TangemSdkManager.kt
@@ -70,9 +70,9 @@ interface TangemSdkManager {
     suspend fun resetToFactorySettings(
         cardId: String,
         allowsRequestAccessCodeFromRepository: Boolean,
-    ): CompletionResult<CardDTO>
+    ): CompletionResult<Boolean>
 
-    suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Unit>
+    suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Boolean>
 
     suspend fun saveAccessCode(accessCode: String, cardsIds: Set<String>): CompletionResult<Unit>
 

--- a/app/src/main/java/com/tangem/tap/domain/sdk/impl/DefaultTangemSdkManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/sdk/impl/DefaultTangemSdkManager.kt
@@ -202,7 +202,7 @@ class DefaultTangemSdkManager(
     override suspend fun resetToFactorySettings(
         cardId: String,
         allowsRequestAccessCodeFromRepository: Boolean,
-    ): CompletionResult<CardDTO> {
+    ): CompletionResult<Boolean> {
         return runTaskAsyncReturnOnMain(
             runnable = ResetToFactorySettingsTask(
                 allowsRequestAccessCodeFromRepository = allowsRequestAccessCodeFromRepository,
@@ -210,10 +210,9 @@ class DefaultTangemSdkManager(
             cardId = cardId,
             initialMessage = Message(resources.getString(R.string.card_settings_reset_card_to_factory)),
         )
-            .map { CardDTO(it) }
     }
 
-    override suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Unit> {
+    override suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Boolean> {
         return runTaskAsyncReturnOnMain(
             runnable = ResetBackupCardTask(userWalletId),
             initialMessage = Message(

--- a/app/src/main/java/com/tangem/tap/domain/sdk/impl/MockTangemSdkManager.kt
+++ b/app/src/main/java/com/tangem/tap/domain/sdk/impl/MockTangemSdkManager.kt
@@ -87,12 +87,12 @@ class MockTangemSdkManager(
     override suspend fun resetToFactorySettings(
         cardId: String,
         allowsRequestAccessCodeFromRepository: Boolean,
-    ): CompletionResult<CardDTO> {
-        return MockProvider.getCardDto()
+    ): CompletionResult<Boolean> {
+        return CompletionResult.Success(true)
     }
 
-    override suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Unit> {
-        return CompletionResult.Success(Unit)
+    override suspend fun resetBackupCard(cardNumber: Int, userWalletId: UserWalletId): CompletionResult<Boolean> {
+        return CompletionResult.Success(true)
     }
 
     override suspend fun saveAccessCode(accessCode: String, cardsIds: Set<String>): CompletionResult<Unit> {

--- a/app/src/main/java/com/tangem/tap/domain/tasks/product/ResetBackupCardTask.kt
+++ b/app/src/main/java/com/tangem/tap/domain/tasks/product/ResetBackupCardTask.kt
@@ -19,11 +19,11 @@ import com.tangem.tap.domain.tasks.UserWalletIdPreflightReadFilter
  */
 internal class ResetBackupCardTask(
     private val userWalletId: UserWalletId,
-) : CardSessionRunnable<Unit> {
+) : CardSessionRunnable<Boolean> {
 
     override val allowsRequestAccessCodeFromRepository: Boolean = false
 
-    override fun run(session: CardSession, callback: CompletionCallback<Unit>) {
+    override fun run(session: CardSession, callback: CompletionCallback<Boolean>) {
         PreflightReadTask(
             readMode = PreflightReadMode.FullCardRead,
             filter = UserWalletIdPreflightReadFilter(expectedUserWalletId = userWalletId),
@@ -35,10 +35,10 @@ internal class ResetBackupCardTask(
         }
     }
 
-    private fun resetCard(session: CardSession, callback: CompletionCallback<Unit>) {
+    private fun resetCard(session: CardSession, callback: CompletionCallback<Boolean>) {
         ResetToFactorySettingsTask(allowsRequestAccessCodeFromRepository).run(session) { result ->
             when (result) {
-                is CompletionResult.Success -> callback(CompletionResult.Success(Unit))
+                is CompletionResult.Success -> callback(CompletionResult.Success(result.data))
                 is CompletionResult.Failure -> callback(CompletionResult.Failure(result.error))
             }
         }

--- a/app/src/main/java/com/tangem/tap/domain/tasks/product/ResetToFactorySettingsTask.kt
+++ b/app/src/main/java/com/tangem/tap/domain/tasks/product/ResetToFactorySettingsTask.kt
@@ -10,13 +10,15 @@ import com.tangem.operations.wallet.PurgeWalletCommand
 
 class ResetToFactorySettingsTask(
     override val allowsRequestAccessCodeFromRepository: Boolean,
-) : CardSessionRunnable<Card> {
+) : CardSessionRunnable<Boolean> {
 
-    override fun run(session: CardSession, callback: (result: CompletionResult<Card>) -> Unit) {
+    private var isResetCompleted = false
+
+    override fun run(session: CardSession, callback: (result: CompletionResult<Boolean>) -> Unit) {
         deleteWallets(session, callback)
     }
 
-    private fun deleteWallets(session: CardSession, callback: (result: CompletionResult<Card>) -> Unit) {
+    private fun deleteWallets(session: CardSession, callback: (result: CompletionResult<Boolean>) -> Unit) {
         val wallet = session.environment.card?.wallets?.lastOrNull().guard {
             resetBackup(session, callback)
             return
@@ -25,6 +27,7 @@ class ResetToFactorySettingsTask(
         PurgeWalletCommand(wallet.publicKey).run(session) { result ->
             when (result) {
                 is CompletionResult.Success -> {
+                    isResetCompleted = true
                     deleteWallets(session, callback)
                 }
                 is CompletionResult.Failure -> callback(CompletionResult.Failure(result.error))
@@ -32,18 +35,18 @@ class ResetToFactorySettingsTask(
         }
     }
 
-    private fun resetBackup(session: CardSession, callback: (result: CompletionResult<Card>) -> Unit) {
+    private fun resetBackup(session: CardSession, callback: (result: CompletionResult<Boolean>) -> Unit) {
         if (session.environment.card?.backupStatus == null ||
             session.environment.card?.backupStatus == Card.BackupStatus.NoBackup
         ) {
-            callback(CompletionResult.Success(session.environment.card!!))
+            callback(CompletionResult.Success(isResetCompleted))
             return
         }
 
         ResetBackupCommand().run(session) { result ->
             when (result) {
                 is CompletionResult.Success -> {
-                    callback(CompletionResult.Success(session.environment.card!!))
+                    callback(CompletionResult.Success(true))
                 }
                 is CompletionResult.Failure -> callback(CompletionResult.Failure(result.error))
             }

--- a/app/src/main/java/com/tangem/tap/features/details/ui/common/utils/ResetToFactory.kt
+++ b/app/src/main/java/com/tangem/tap/features/details/ui/common/utils/ResetToFactory.kt
@@ -5,8 +5,11 @@ import com.tangem.domain.models.scan.CardDTO
 import com.tangem.tap.features.details.ui.cardsettings.TextReference
 import com.tangem.wallet.R
 
-internal fun getResetToFactoryDescription(card: CardDTO, typesResolver: CardTypesResolver): TextReference {
-    return if (card.backupStatus?.isActive != true || typesResolver.isTangemTwins()) {
+internal fun getResetToFactoryDescription(
+    backupStatus: CardDTO.BackupStatus?,
+    typesResolver: CardTypesResolver,
+): TextReference {
+    return if (backupStatus?.isActive != true || typesResolver.isTangemTwins()) {
         TextReference.Res(R.string.reset_card_without_backup_to_factory_message)
     } else {
         TextReference.Res(R.string.reset_card_with_backup_to_factory_message)

--- a/common/routing/build.gradle.kts
+++ b/common/routing/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     /* Domain */
     implementation(projects.domain.qrScanning.models)
+    implementation(projects.domain.models)
     implementation(projects.domain.tokens.models)
     implementation(projects.domain.wallets.models)
     implementation(projects.domain.staking.models)

--- a/common/routing/src/main/kotlin/com/tangem/common/routing/AppRoute.kt
+++ b/common/routing/src/main/kotlin/com/tangem/common/routing/AppRoute.kt
@@ -5,6 +5,7 @@ import com.tangem.common.routing.bundle.RouteBundleParams
 import com.tangem.common.routing.bundle.bundle
 import com.tangem.common.routing.entity.SerializableIntent
 import com.tangem.core.decompose.navigation.Route
+import com.tangem.domain.models.scan.CardDTO
 import com.tangem.domain.qrscanning.models.SourceType
 import com.tangem.domain.staking.model.stakekit.Yield
 import com.tangem.domain.tokens.model.CryptoCurrency
@@ -143,15 +144,26 @@ sealed class AppRoute(val path: String) : Route {
     @Serializable
     data object AppSettings : AppRoute(path = "/app_settings")
 
+    /**
+     * Reset to factory route
+     *
+     * @property userWalletId     user wallet id
+     * @property cardSpecificInfo info about card that was scanned on CardSettings
+     */
     @Serializable
     data class ResetToFactory(
         val userWalletId: UserWalletId,
-    ) : AppRoute(path = "/reset_to_factory/${userWalletId.stringValue}"), RouteBundleParams {
+        val cardSpecificInfo: CardSpecificInfo,
+    ) : AppRoute(path = "/reset_to_factory/${userWalletId.stringValue}/$cardSpecificInfo"), RouteBundleParams {
 
         override fun getBundle(): Bundle = bundle(serializer())
 
+        @Serializable
+        data class CardSpecificInfo(val cardId: String, val backupStatus: CardDTO.BackupStatus?)
+
         companion object {
             const val USER_WALLET_ID = "userWalletId"
+            const val CARD_SPECIFIC_DATA = "cardSpecificInfo"
         }
     }
 

--- a/domain/card/src/main/kotlin/com/tangem/domain/card/ResetCardUseCase.kt
+++ b/domain/card/src/main/kotlin/com/tangem/domain/card/ResetCardUseCase.kt
@@ -2,7 +2,6 @@ package com.tangem.domain.card
 
 import arrow.core.Either
 import com.tangem.domain.card.models.ResetCardError
-import com.tangem.domain.models.scan.CardDTO
 import com.tangem.domain.wallets.models.UserWalletId
 
 /**
@@ -12,13 +11,18 @@ import com.tangem.domain.wallets.models.UserWalletId
  */
 interface ResetCardUseCase {
 
-    /** Reset card [card] to factory settings */
-    suspend operator fun invoke(card: CardDTO): Either<ResetCardError, Unit>
+    /** Reset card [cardId] to factory settings */
+    suspend operator fun invoke(cardId: String, params: ResetCardUserCodeParams): Either<ResetCardError, Boolean>
 
-    /** Reset backup card [cardNumber] with expected [UserWalletId] using [card] of reset card */
+    /** Reset backup card [cardNumber] with expected [UserWalletId] using [params] of reset card */
     suspend operator fun invoke(
         cardNumber: Int,
-        card: CardDTO,
+        params: ResetCardUserCodeParams,
         userWalletId: UserWalletId,
-    ): Either<ResetCardError, Unit>
+    ): Either<ResetCardError, Boolean>
 }
+
+data class ResetCardUserCodeParams(
+    val isAccessCodeSet: Boolean,
+    val isPasscodeSet: Boolean?,
+)

--- a/domain/models/build.gradle.kts
+++ b/domain/models/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     alias(deps.plugins.kotlin.jvm)
+    alias(deps.plugins.kotlin.serialization)
     id("configuration")
 }
 
 dependencies {
     implementation(deps.tangem.card.core)
     implementation(deps.moshi.kotlin)
+    implementation(deps.kotlin.serialization)
 }

--- a/domain/models/src/main/kotlin/com/tangem/domain/models/scan/CardDTO.kt
+++ b/domain/models/src/main/kotlin/com/tangem/domain/models/scan/CardDTO.kt
@@ -8,6 +8,8 @@ import com.tangem.common.card.EncryptionMode
 import com.tangem.crypto.hdWallet.DerivationPath
 import com.tangem.crypto.hdWallet.bip32.ExtendedPublicKey
 import com.tangem.operations.attestation.Attestation
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 import com.tangem.common.card.FirmwareVersion as SdkFirmwareVersion
 
@@ -298,11 +300,19 @@ data class CardDTO(
         }
     }
 
+    @Serializable
     sealed class BackupStatus {
+
+        @Serializable
+        @SerialName("card_linked")
         data class CardLinked(val cardCount: Int) : BackupStatus()
 
+        @Serializable
+        @SerialName("active")
         data class Active(val cardCount: Int) : BackupStatus()
 
+        @Serializable
+        @SerialName("no_backup")
         data object NoBackup : BackupStatus()
 
         val isActive: Boolean


### PR DESCRIPTION
1. Исправил баг на CardSettings. Информация отрисовывалась не для отсканированной карты, а для карты сохраненной в UserWallet.
2. Исправил баг на CardSettings. Разрешил сканирование CardLinked карт.
3. Исправил баг на ResetToFactory. Требовало сделать первый ресет не той карты, которая была отсканирована на CardSettings, а той, что сохранена в UserWallet.
4. Исправил баг на ResetToFactory. Исправил переход на Home скрин после удаления последнего кошелька.
5. Исправил баг на ResetToFactory. После ресета карты делается проверка, что ресет успешно завершен.

